### PR TITLE
Add optional typing to FP

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,6 @@ export {
     supportsEntropy,
     Vote,
     Diff,
-    TypedFP,
 } from "./lib/machine/Aspect";
 export {
     fingerprintRunner,

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -41,12 +41,17 @@ import {
 } from "../machine/fingerprintSupport";
 
 /**
+ * [lib, version]
+ */
+export type NpmDepData = string[];
+
+/**
  * Construct an npmdep fingerprint from the given library and version
  * @param {string} lib
  * @param {string} version
  * @return {FP}
  */
-export function createNpmDepFingerprint(lib: string, version: string): FP {
+export function createNpmDepFingerprint(lib: string, version: string): FP<NpmDepData> {
     const data = [lib, version];
     return {
         type: NpmDepsName,
@@ -83,7 +88,7 @@ export function deconstructNpmDepsFingerprintName(fingerprintName: string): stri
     }
 }
 
-export const createNpmDepsFingerprints: ExtractFingerprint = async p => {
+export const createNpmDepsFingerprints: ExtractFingerprint<FP<NpmDepData>> = async p => {
     const file = await p.getFile("package.json");
 
     if (file) {
@@ -128,7 +133,7 @@ export const createNpmCoordinatesFingerprint: ExtractFingerprint = async p => {
 
 };
 
-export const applyNpmDepsFingerprint: ApplyFingerprint = async (p, fp) => {
+export const applyNpmDepsFingerprint: ApplyFingerprint<FP<NpmDepData>> = async (p, fp) => {
     const file = await p.getFile("package.json");
     if (file) {
         const log = new LoggingProgressLog("npm install");
@@ -168,7 +173,10 @@ export const diffNpmCoordinatesFingerprints: DiffSummaryFingerprint = (diff, tar
 
 const NpmDepsName = "npm-project-deps";
 
-export const NpmDeps: Aspect = {
+/**
+ * Aspect emitting 0 or more npm dependencies fingerprints.
+ */
+export const NpmDeps: Aspect<FP<NpmDepData>> = {
     displayName: "NPM dependencies",
     name: NpmDepsName,
     extract: createNpmDepsFingerprints,

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -29,12 +29,13 @@ import * as _ from "lodash";
 /**
  * Fingerprint interface. An Aspect can emit zero or more fingerprints,
  * which must have the same data type.
+ * @param DATA type parameter for data
  */
-export interface FP {
+export interface FP<DATA = any> {
     type?: string;
     name: string;
     sha: string;
-    data: any;
+    data: DATA;
     version?: string;
     abbreviation?: string;
 }
@@ -66,13 +67,6 @@ export interface Diff {
     providerId: string;
     channel: string;
     branch: string;
-}
-
-/**
- * Fingerprint that has a typed data payload
- */
-export interface TypedFP<T> extends FP {
-    data: T;
 }
 
 /**


### PR DESCRIPTION
Avoids being forced to use `any` for fingerprint data. Can make `Aspect` implementations more strongly typed.

Backward compatible except for removal of old `TypedFP`, which is barely used and now unnecessary.