### PR TITLE
Remove the usage of gobal aspects map

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,13 +15,12 @@
  */
 
 export {
-    createPullRequestEditModeMaker,
+    createPullRequestTransformPresentation,
     fingerprintSupport,
     forFingerprints,
     diffOnlyHandler,
     DefaultTargetDiffHandler,
-    DefaultEditModeMaker,
-    EditModeMaker,
+    DefaultTransformPresentation,
 } from "./lib/machine/fingerprintSupport";
 export {
     BaseAspect,

--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,7 @@
  */
 
 export {
+    createPullRequestEditModeMaker,
     fingerprintSupport,
     forFingerprints,
     diffOnlyHandler,

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,10 @@ export {
     diffOnlyHandler,
     DefaultTargetDiffHandler,
     DefaultTransformPresentation,
+    PullRequestTransformPresentationOptions,
+    FingerprintImpactHandlerConfig,
+    FingerprintOptions,
+    RegisterFingerprintImpactHandler,
 } from "./lib/machine/fingerprintSupport";
 export {
     BaseAspect,

--- a/lib/checktarget/callbacks.ts
+++ b/lib/checktarget/callbacks.ts
@@ -30,10 +30,11 @@ import {
 import {
     findSdmGoalOnCommit,
     Goal,
+    SdmGoalState,
     updateGoal,
     UpdateSdmGoalParams,
 } from "@atomist/sdm";
-import { SdmGoalState } from "@atomist/sdm-core/lib/typings/types";
+import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import {
     Aspect,
     Diff,
@@ -42,6 +43,7 @@ import {
 } from "../machine/Aspect";
 import {
     FingerprintImpactHandlerConfig,
+    FingerprintOptions,
 } from "../machine/fingerprintSupport";
 import {
     getDiffSummary,
@@ -125,7 +127,7 @@ async function editGoal(ctx: HandlerContext, diff: GitCoordinate, goal: Goal, pa
  *
  * @param config
  */
-export function votes(config: FingerprintImpactHandlerConfig):
+export function votes(config: FingerprintOptions & FingerprintImpactHandlerConfig):
     (ctx: HandlerContext, votes: Vote[], coord: GitCoordinate, channel: string) => Promise<any> {
 
     return async (ctx, vs: Vote[], coord, channel) => {
@@ -149,6 +151,7 @@ export function votes(config: FingerprintImpactHandlerConfig):
                     channel,
                     voteResults: result,
                     coord,
+                    aspects: toArray(config.aspects || []),
                 });
             } else {
                 logger.warn(`no linked repo channel.  Not sending target message`);

--- a/lib/checktarget/callbacks.ts
+++ b/lib/checktarget/callbacks.ts
@@ -139,28 +139,24 @@ export function votes(config: FingerprintOptions & FingerprintImpactHandlerConfi
 
         if (result.failed) {
 
-            if (channel) {
-                await config.messageMaker({
-                    ctx,
-                    msgId: updateableMessage(
-                        [].concat(
-                            result.failedVotes.map(vote => vote.fingerprint.sha),
-                            result.failedVotes.map(vote => vote.fpTarget.sha)),
-                        coord,
-                        channel),
-                    channel,
-                    voteResults: result,
-                    coord,
-                    aspects: toArray(config.aspects || []),
-                });
-            } else {
-                logger.warn(`no linked repo channel.  Not sending target message`);
-            }
+            await config.messageMaker({
+                ctx,
+                msgId: updateableMessage(
+                    [].concat(
+                        result.failedVotes.map(vote => vote.fingerprint.sha),
+                        result.failedVotes.map(vote => vote.fpTarget.sha)),
+                    coord),
+                channel,
+                voteResults: result,
+                coord,
+                aspects: toArray(config.aspects || []),
+            });
 
             goalState = {
                 state: SdmGoalState.failure,
                 description: `compliance check for ${commaSeparatedList(result.failedVotes.map(vote => vote.fingerprint.name))} has failed`,
             };
+
         } else {
 
             goalState = {

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -16,6 +16,7 @@
 
 import {
     addressSlackChannelsFromContext,
+    addressWeb,
     buttonForCommand,
     HandlerContext,
     HandlerResult,
@@ -215,10 +216,22 @@ export const messageMaker: MessageMaker = async params => {
     message.attachments[message.attachments.length - 1].footer = slackFooter();
     message.attachments[message.attachments.length - 1].ts = slackTs();
 
-    return params.ctx.messageClient.send(
-        message,
-        await addressSlackChannelsFromContext(params.ctx, params.channel),
-        // {id: params.msgId} if you want to update messages if the target goal has not changed
-        { id: params.msgId },
-    );
+    if (!!params.channel) {
+        return params.ctx.messageClient.send(
+            message,
+            await addressSlackChannelsFromContext(params.ctx, params.channel),
+            // {id: params.msgId} if you want to update messages if the target goal has not changed
+            { id: params.msgId },
+        );
+    } else {
+        return params.ctx.messageClient.send(
+            message,
+            addressWeb(),
+            // {id: params.msgId} if you want to update messages if the target goal has not changed
+            { id: params.msgId },
+        );
+    }
+
+
+
 };

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -232,6 +232,4 @@ export const messageMaker: MessageMaker = async params => {
         );
     }
 
-
-
 };

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -183,7 +183,7 @@ function applyAll(params: MessageMakerParams): Attachment {
                     msgId: params.msgId,
                     fingerprints: params.voteResults.failedVotes.map(vote => toName(vote.fpTarget.type, vote.fpTarget.name)).join(","),
                     title: `Apply all of ${fingerprints.join(", ")}`,
-                    body: params.voteResults.failedVotes.map(v => prBody(v, params.aspects)).join("\n"),
+                    body: params.voteResults.failedVotes.map(v => prBody(v, params.aspects)).join("\n---\n"),
                     targets: {
                         owner: params.coord.owner,
                         repo: params.coord.repo,

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -158,8 +158,6 @@ function ignoreButton(params: MessageMakerParams): Action {
 }
 
 /**
- *
- * @param params
  */
 function applyAll(params: MessageMakerParams): Attachment {
 

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -96,9 +96,8 @@ function oneFingerprint(params: MessageMakerParams, vote: Vote): Attachment {
                 UpdateTargetFingerprintName,
                 {
                     msgId: params.msgId,
-                    fptype: vote.fingerprint.type,
-                    fpname: vote.fingerprint.name,
-                    fpsha: vote.fingerprint.sha,
+                    targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
+                    sha: vote.fingerprint.sha,
                 },
             ),
         ],

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -136,7 +136,7 @@ export function ignoreCommand(aspects: Aspect[]): CommandHandlerRegistration<Ign
 
             const msg = slackInfoMessage(
                 "New Fingerprint Target",
-                `Dismissed fingerprint target updates for ${fingerprints.map(f => codeLine(f)).join(", ")}`,
+                `Dismissed fingerprint target updates for ${fingerprints.map(codeLine).join(", ")}`,
             );
 
             // collapse the message

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -77,39 +77,36 @@ export type MessageMaker = (params: MessageMakerParams) => Promise<HandlerResult
  * @param vote
  */
 function oneFingerprint(params: MessageMakerParams, vote: Vote): Attachment {
-    return {
-        title: orDefault(() => vote.summary.title, "New Target"),
-        text: orDefault(() => vote.summary.description, vote.text),
-        color: "warning",
-        fallback: "Fingerprint Update",
-        mrkdwn_in: ["text"],
-        actions: [
-            buttonForCommand(
-                { text: "Apply" },
-                ApplyTargetFingerprintName,
-                {
-                    msgId: params.msgId,
-                    targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
-                    title: applyFingerprintTitle(vote.fpTarget, params.aspects),
-                    branch: vote.diff.branch,
-                    body: prBody(vote, params.aspects),
-                    targets: {
-                        owner: vote.diff.owner,
-                        repo: vote.diff.repo,
+    return slackInfoMessage(
+        orDefault(() => vote.summary.title, "New Target"),
+        orDefault(() => vote.summary.description, vote.text), {
+            actions: [
+                buttonForCommand(
+                    { text: "Apply" },
+                    ApplyTargetFingerprintName,
+                    {
+                        msgId: params.msgId,
+                        targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
+                        title: applyFingerprintTitle(vote.fpTarget, params.aspects),
                         branch: vote.diff.branch,
+                        body: prBody(vote, params.aspects),
+                        targets: {
+                            owner: vote.diff.owner,
+                            repo: vote.diff.repo,
+                            branch: vote.diff.branch,
+                        },
+                    }),
+                buttonForCommand(
+                    { text: "Set New Target" },
+                    UpdateTargetFingerprintName,
+                    {
+                        msgId: params.msgId,
+                        targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
+                        sha: vote.fingerprint.sha,
                     },
-                }),
-            buttonForCommand(
-                { text: "Set New Target" },
-                UpdateTargetFingerprintName,
-                {
-                    msgId: params.msgId,
-                    targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
-                    sha: vote.fingerprint.sha,
-                },
-            ),
-        ],
-    };
+                ),
+            ],
+        }).attachments[0];
 }
 
 interface IgnoreParameters extends ParameterType {
@@ -177,7 +174,7 @@ function applyAll(params: MessageMakerParams): Attachment {
     return {
         title: "Apply all Changes",
         text: `Apply all changes from ${params.voteResults.failedVotes.map(vote => codeLine(vote.name)).join(", ")}`,
-        color: "warning",
+        color: "#D7B958",
         fallback: "Fingerprint Update",
         mrkdwn_in: ["text"],
         actions: [

--- a/lib/checktarget/messageMaker.ts
+++ b/lib/checktarget/messageMaker.ts
@@ -39,7 +39,10 @@ import {
     ApplyTargetFingerprintName,
 } from "../handlers/commands/applyFingerprint";
 import { UpdateTargetFingerprintName } from "../handlers/commands/updateTarget";
-import { Vote } from "../machine/Aspect";
+import {
+    Aspect,
+    Vote,
+} from "../machine/Aspect";
 import {
     applyFingerprintTitle,
     GitCoordinate,
@@ -53,6 +56,7 @@ export interface MessageMakerParams {
     msgId: string;
     channel: string;
     coord: GitCoordinate;
+    aspects: Aspect[];
 }
 
 export type MessageMaker = (params: MessageMakerParams) => Promise<HandlerResult>;
@@ -78,9 +82,9 @@ function oneFingerprint(params: MessageMakerParams, vote: Vote): Attachment {
                 {
                     msgId: params.msgId,
                     targetfingerprint: toName(vote.fpTarget.type, vote.fpTarget.name),
-                    title: applyFingerprintTitle(vote.fpTarget),
+                    title: applyFingerprintTitle(vote.fpTarget, params.aspects),
                     branch: vote.diff.branch,
-                    body: prBody(vote),
+                    body: prBody(vote, params.aspects),
                     targets: {
                         owner: vote.diff.owner,
                         repo: vote.diff.repo,
@@ -157,7 +161,7 @@ function applyAll(params: MessageMakerParams): Attachment {
                     msgId: params.msgId,
                     fingerprints: params.voteResults.failedVotes.map(vote => toName(vote.fpTarget.type, vote.fpTarget.name)).join(","),
                     title: `Apply all of \`${params.voteResults.failedVotes.map(vote => vote.fpTarget.name).join(", ")}\``,
-                    body: params.voteResults.failedVotes.map(prBody).join("\n"),
+                    body: params.voteResults.failedVotes.map(v => prBody(v, params.aspects)).join("\n"),
                     targets: {
                         owner: params.coord.owner,
                         repo: params.coord.repo,

--- a/lib/handlers/commands/applyFingerprint.ts
+++ b/lib/handlers/commands/applyFingerprint.ts
@@ -85,7 +85,7 @@ export function runAllFingerprintAppliers(aspects: Aspect[]): CodeTransform<Appl
         await cli.addressChannels(message, { id: cli.parameters.msgId });
 
         const { type, name } = fromName(cli.parameters.targetfingerprint);
-        const result = pushFingerprint(
+        const result = await pushFingerprint(
             (p as GitProject),
             aspects,
             await queryPreferences(
@@ -122,10 +122,15 @@ export function runFingerprintAppliersBySha(aspects: Aspect[]): CodeTransform<Ap
             options: QueryNoCacheOptions,
         });
 
-        const result = pushFingerprint(
+        const result = await pushFingerprint(
             (p as GitProject),
             aspects,
-            fp.SourceFingerprint as any);
+            {
+                type,
+                name,
+                data: JSON.parse(fp.SourceFingerprint.data),
+                sha: fp.SourceFingerprint.sha,
+            });
 
         if (result) {
             return p;

--- a/lib/handlers/commands/applyFingerprint.ts
+++ b/lib/handlers/commands/applyFingerprint.ts
@@ -151,7 +151,7 @@ function runEveryFingerprintApplication(aspects: Aspect[]): CodeTransform<ApplyT
 
         const message = slackInfoMessage(
             "Apply Fingerprint Targets",
-            `Applying fingerprint targets ${fingerprints.map(fp => codeLine(fp)).join(", ")} to ${bold(`${p.id.owner}/${p.id.repo}`)}`);
+            `Applying fingerprint targets ${fingerprints.map(codeLine).join(", ")} to ${bold(`${p.id.owner}/${p.id.repo}`)}`);
 
         await cli.addressChannels(message, { id: cli.parameters.msgId });
 

--- a/lib/handlers/commands/applyFingerprint.ts
+++ b/lib/handlers/commands/applyFingerprint.ts
@@ -101,7 +101,6 @@ export function runAllFingerprintAppliers(aspects: Aspect[]): CodeTransform<Appl
     };
 }
 
-
 export function runFingerprintAppliersBySha(aspects: Aspect[]): CodeTransform<ApplyTargetFingerprintByShaParameters> {
     return async (p, cli) => {
 

--- a/lib/handlers/commands/applyFingerprint.ts
+++ b/lib/handlers/commands/applyFingerprint.ts
@@ -29,6 +29,7 @@ import {
     slackInfoMessage,
     slackSuccessMessage,
     SoftwareDeliveryMachine,
+    TransformPresentation,
 } from "@atomist/sdm";
 import {
     bold,
@@ -44,7 +45,6 @@ import {
     FP,
 } from "../../machine/Aspect";
 import { aspectOf } from "../../machine/Aspects";
-import { EditModeMaker } from "../../machine/fingerprintSupport";
 import {
     applyFingerprintTitle,
     prBodyFromFingerprint,
@@ -211,7 +211,7 @@ export const ApplyTargetFingerprintName = "ApplyTargetFingerprint";
 export function applyTarget(
     sdm: SoftwareDeliveryMachine,
     aspects: Aspect[],
-    presentation: EditModeMaker): CodeTransformRegistration<ApplyTargetFingerprintParameters> {
+    presentation: TransformPresentation<ApplyTargetParameters>): CodeTransformRegistration<ApplyTargetFingerprintParameters> {
 
     return {
         name: ApplyTargetFingerprintName,
@@ -242,7 +242,7 @@ export const ApplyTargetFingerprintByShaName = "ApplyTargetFingerprintBySha";
 export function applyTargetBySha(
     sdm: SoftwareDeliveryMachine,
     aspects: Aspect[],
-    presentation: EditModeMaker): CodeTransformRegistration<ApplyTargetFingerprintByShaParameters> {
+    presentation: TransformPresentation<ApplyTargetParameters>): CodeTransformRegistration<ApplyTargetFingerprintByShaParameters> {
 
     return {
         name: ApplyTargetFingerprintByShaName,
@@ -274,7 +274,7 @@ export const ApplyAllFingerprintsName = "ApplyAllFingerprints";
 export function applyTargets(
     sdm: SoftwareDeliveryMachine,
     registrations: Aspect[],
-    presentation: EditModeMaker,
+    presentation: TransformPresentation<ApplyTargetParameters>,
 ): CodeTransformRegistration<ApplyTargetFingerprintsParameters> {
     return {
         name: ApplyAllFingerprintsName,

--- a/lib/handlers/commands/broadcast.ts
+++ b/lib/handlers/commands/broadcast.ts
@@ -118,7 +118,7 @@ function targetUpdateMessage(cli: CommandListenerInvocation<BroadcastFingerprint
                              type: string,
                              name: string): string {
 
-    const aspect = aspectOf({ type, name, data: {}, sha: "" }, aspects);
+    const aspect = aspectOf({ type }, aspects);
     const displayableName = !!aspect ? displayName(aspect, { type, name, data: {}, sha: "" }) : name;
 
     return `${user(cli.parameters.author)} has updated the target version of ${codeLine(displayableName)}.

--- a/lib/handlers/commands/broadcast.ts
+++ b/lib/handlers/commands/broadcast.ts
@@ -20,12 +20,11 @@ import {
     logger,
     ParameterType,
 } from "@atomist/automation-client";
-import {
-    broadcastFingerprint,
-} from "@atomist/clj-editors";
+import { broadcastFingerprint } from "@atomist/clj-editors";
 import {
     actionableButton,
     CommandHandlerRegistration,
+    CommandListener,
     CommandListenerInvocation,
     slackQuestionMessage,
     slackWarningMessage,
@@ -40,9 +39,12 @@ import {
     fromName,
     toName,
 } from "../../adhoc/preferences";
-import { FP } from "../../machine/Aspect";
 import {
-    applyToAspect,
+    Aspect,
+    FP,
+} from "../../machine/Aspect";
+import {
+    aspectOf,
     displayName,
 } from "../../machine/Aspects";
 import { applyFingerprintTitle } from "../../support/messages";
@@ -54,6 +56,7 @@ import {
 
 export function askAboutBroadcast(
     cli: CommandListenerInvocation,
+    aspects: Aspect[],
     fp: FP,
     msgId: string): Promise<void> {
 
@@ -68,7 +71,7 @@ export function askAboutBroadcast(
                     {
                         text: "Broadcast Nudge",
                     },
-                    BroadcastFingerprintNudge,
+                    BroadcastFingerprintNudgeName,
                     {
                         author,
                         msgId,
@@ -82,8 +85,8 @@ export function askAboutBroadcast(
                     },
                     BroadcastFingerprintMandateName,
                     {
-                        title: applyFingerprintTitle(fp),
-                        body: applyFingerprintTitle(fp),
+                        title: applyFingerprintTitle(fp, aspects),
+                        body: applyFingerprintTitle(fp, aspects),
                         branch: "master",
                         fingerprint: toName(fp.type, fp.name),
                         msgId: id,
@@ -109,9 +112,13 @@ export interface BroadcastFingerprintNudgeParameters extends ParameterType {
     msgId?: string;
 }
 
-function targetUpdateMessage(cli: CommandListenerInvocation<BroadcastFingerprintNudgeParameters>, type: string, name: string): string {
+function targetUpdateMessage(cli: CommandListenerInvocation<BroadcastFingerprintNudgeParameters>,
+                             aspects: Aspect[],
+                             type: string,
+                             name: string): string {
 
-    const displayableName: string = applyToAspect({ type, name, data: {}, sha: "" }, displayName);
+    const aspect = aspectOf({ type, name, data: {}, sha: "" }, aspects);
+    const displayableName = !!aspect ? displayName(aspect, { type, name, data: {}, sha: "" }) : name;
 
     return `${user(cli.parameters.author)} has updated the target version of ${codeLine(displayableName)}.
 
@@ -132,95 +139,100 @@ interface FingerprintedRepo {
  *
  * @param cli
  */
-function broadcastNudge(cli: CommandListenerInvocation<BroadcastFingerprintNudgeParameters>): Promise<any> {
+function broadcastNudge(aspects: Aspect[]): CommandListener<BroadcastFingerprintNudgeParameters> {
+    return async cli => {
+        const msgId = `broadcastNudge-${cli.parameters.name}-${cli.parameters.sha}`;
 
-    const msgId = `broadcastNudge-${cli.parameters.name}-${cli.parameters.sha}`;
+        return broadcastFingerprint(
+            async (type: string, name: string): Promise<FingerprintedRepo[]> => {
 
-    return broadcastFingerprint(
-        async (type: string, name: string): Promise<FingerprintedRepo[]> => {
+                const data: FindOtherRepos.Query = await (findTaggedRepos(cli.context.graphClient))(type, name);
+                logger.info(
+                    `findTaggedRepos(broadcastNudge) ${
+                        JSON.stringify(
+                            data.headCommitsWithFingerprint,
+                        )
+                        }`);
+                return data.headCommitsWithFingerprint
+                    .filter(head => !!head.branch && !!head.branch.name && head.branch.name === "master")
+                    .map(x => {
+                        return {
+                            name: x.repo.name,
+                            owner: x.repo.owner,
+                            channels: x.repo.channels,
+                            branches: [{
+                                commit: {
+                                    ...x.commit,
+                                    analysis: x.analysis,
+                                },
+                            }],
+                        };
+                    });
+            },
+            {
+                ...fromName(cli.parameters.fingerprint),
+                sha: cli.parameters.sha,
+            },
+            (owner: string, repo: string, channel: string) => {
+                const { type, name } = fromName(cli.parameters.fingerprint);
+                const message = slackWarningMessage("Fingerprint Target", targetUpdateMessage(cli, aspects, type, name), cli.context);
 
-            const data: FindOtherRepos.Query = await (findTaggedRepos(cli.context.graphClient))(type, name);
-            logger.info(
-                `findTaggedRepos(broadcastNudge) ${
-                JSON.stringify(
-                    data.headCommitsWithFingerprint,
-                )
-                }`);
-            return data.headCommitsWithFingerprint
-                .filter(head => !!head.branch && !!head.branch.name && head.branch.name === "master")
-                .map(x => {
-                    return {
-                        name: x.repo.name,
-                        owner: x.repo.owner,
-                        channels: x.repo.channels,
-                        branches: [{
-                            commit: {
-                                ...x.commit,
-                                analysis: x.analysis,
+                message.attachments.push({
+                    text: `Shall we update repository to use the new ${codeLine(name)} target?`,
+                    fallback: `Shall we update repository to use the new ${codeLine(name)} target?`,
+                    actions: [
+                        buttonForCommand(
+                            {
+                                text: "Update",
                             },
-                        }],
-                    };
-            });
-        },
-        {
-            ...fromName(cli.parameters.fingerprint),
-            sha: cli.parameters.sha,
-        },
-        (owner: string, repo: string, channel: string) => {
-            const { type, name } = fromName(cli.parameters.fingerprint);
-            const message = slackWarningMessage("Fingerprint Target", targetUpdateMessage(cli, type, name), cli.context);
+                            ApplyTargetFingerprintName,
+                            {
+                                msgId,
+                                targetfingerprint: cli.parameters.fingerprint,
+                                title: `Updated target for ${name}`,
+                                body: cli.parameters.reason,
+                            },
+                        ),
+                    ],
+                    callback_id: "atm-confirm-done",
+                });
 
-            message.attachments.push({
-                text: `Shall we update repository to use the new ${codeLine(name)} target?`,
-                fallback: `Shall we update repository to use the new ${codeLine(name)} target?`,
-                actions: [
-                    buttonForCommand(
-                        {
-                            text: "Update",
-                        },
-                        ApplyTargetFingerprintName,
-                        {
-                            msgId,
-                            targetfingerprint: cli.parameters.fingerprint,
-                            title: `Updated target for ${name}`,
-                            body: cli.parameters.reason,
-                        },
-                    ),
-                ],
-                callback_id: "atm-confirm-done",
-            });
-
-            // each channel with a repo containing this fingerprint gets a message
-            // use the msgId passed in so all the msgIds across the different channels are the same
-            return cli.context.messageClient.addressChannels(message, channel, { id: msgId });
-        },
-    );
+                // each channel with a repo containing this fingerprint gets a message
+                // use the msgId passed in so all the msgIds across the different channels are the same
+                return cli.context.messageClient.addressChannels(message, channel, { id: msgId });
+            },
+        );
+    };
 }
 
-export const BroadcastFingerprintNudge: CommandHandlerRegistration<BroadcastFingerprintNudgeParameters> = {
-    name: "BroadcastFingerprintNudge",
-    description: "message all Channels linked to Repos that contain a particular fingerprint",
-    parameters: {
-        fingerprint: { required: true },
-        sha: {
-            required: true,
-            description: "sha of fingerprint to broadcast",
+const BroadcastFingerprintNudgeName = "BroadcastFingerprintNudge";
+
+export function broadcastFingerprintNudge(aspects: Aspect[]): CommandHandlerRegistration<BroadcastFingerprintNudgeParameters> {
+    return {
+        name: BroadcastFingerprintNudgeName,
+        description: "message all Channels linked to Repos that contain a particular fingerprint",
+        parameters: {
+            fingerprint: { required: true },
+            sha: {
+                required: true,
+                description: "sha of fingerprint to broadcast",
+            },
+            reason: {
+                required: true,
+                control: "textarea",
+                pattern: /[\s\S]*/,
+                description: "always give a reason why we're releasing the nudge",
+            },
+            author: {
+                required: true,
+                description: "author of the Nudge",
+            },
+            msgId: {
+                required: false,
+                displayable: false,
+            },
         },
-        reason: {
-            required: true,
-            control: "textarea",
-            pattern: /[\s\S]*/,
-            description: "always give a reason why we're releasing the nudge",
-        },
-        author: {
-            required: true,
-            description: "author of the Nudge",
-        },
-        msgId: {
-            required: false,
-            displayable: false,
-        },
-    },
-    listener: broadcastNudge,
-    autoSubmit: true,
-};
+        listener: broadcastNudge(aspects),
+        autoSubmit: true,
+    };
+}

--- a/lib/handlers/commands/broadcast.ts
+++ b/lib/handlers/commands/broadcast.ts
@@ -34,6 +34,7 @@ import {
     italic,
     user,
 } from "@atomist/slack-messages";
+import * as _ from "lodash";
 import { findTaggedRepos } from "../../adhoc/fingerprints";
 import {
     fromName,
@@ -60,7 +61,7 @@ export function askAboutBroadcast(
     fp: FP,
     msgId: string): Promise<void> {
 
-    const author = cli.context.source.slack.user.id;
+    const author = _.get(cli.context.source, "slack.user.id") || _.get(cli.context.source, "web.identity.sub");
     const id = msgId || guid();
     const message = slackQuestionMessage(
         "Broadcast Fingerprint Target",

--- a/lib/handlers/commands/updateTarget.ts
+++ b/lib/handlers/commands/updateTarget.ts
@@ -67,7 +67,7 @@ export class SetTargetFingerprintFromLatestMasterParameters {
 
     @Parameter({
         required: true,
-        pattern: /[\w-]+::[\w-]+/,
+        pattern: /[\w-]+::[\w-]+(::[\w-]+)?/,
         description: `Please enter the fingerprint (format type::name)`,
         displayName: `Please enter the fingerprint (format type::name)`,
     })

--- a/lib/handlers/commands/updateTarget.ts
+++ b/lib/handlers/commands/updateTarget.ts
@@ -145,7 +145,7 @@ export class UpdateTargetFingerprintParameters {
     public targetfingerprint: string;
 
     @Parameter({ required: false, type: "boolean" })
-    public broadcast: boolean
+    public broadcast: boolean;
 }
 
 export const UpdateTargetFingerprintName = "RegisterTargetFingerprint";

--- a/lib/handlers/commands/updateTarget.ts
+++ b/lib/handlers/commands/updateTarget.ts
@@ -143,6 +143,9 @@ export class UpdateTargetFingerprintParameters {
 
     @Parameter({ required: true })
     public targetfingerprint: string;
+
+    @Parameter({ required: false, type: "boolean" })
+    public broadcast: boolean
 }
 
 export const UpdateTargetFingerprintName = "RegisterTargetFingerprint";
@@ -184,7 +187,9 @@ export function updateTargetFingerprint(sdm: SoftwareDeliveryMachine,
             };
 
             await (setFPTarget(cli.context.graphClient))(type, name, fingerprint);
-            return askAboutBroadcast(cli, aspects, fingerprint, cli.parameters.msgId);
+            if (!!cli.parameters.broadcast) {
+                return askAboutBroadcast(cli, aspects, fingerprint, cli.parameters.msgId);
+            }
         },
     };
 }

--- a/lib/machine/Aspects.ts
+++ b/lib/machine/Aspects.ts
@@ -31,7 +31,7 @@ export function displayValue(aspect: Aspect, fp: FP): string {
     if (!!aspect.toDisplayableFingerprint) {
         return aspect.toDisplayableFingerprint(fp);
     } else {
-        return JSON.stringify(fp.data);
+        return JSON.stringify(fp.data, undefined, 2);
     }
 }
 

--- a/lib/machine/Aspects.ts
+++ b/lib/machine/Aspects.ts
@@ -35,6 +35,6 @@ export function displayValue(aspect: Aspect, fp: FP): string {
     }
 }
 
-export function aspectOf(fingerprint: FP, aspects: Aspect[]): Aspect | undefined {
+export function aspectOf(fingerprint: Pick<FP, "type">, aspects: Aspect[]): Aspect | undefined {
     return aspects.find(a => a.name === fingerprint.type);
 }

--- a/lib/machine/Aspects.ts
+++ b/lib/machine/Aspects.ts
@@ -21,29 +21,20 @@ import {
 
 export function displayName(aspect: Aspect, fp: FP): string {
     if (!!aspect.toDisplayableFingerprintName) {
-        return `${aspect.toDisplayableFingerprintName(fp.name)}`;
+        return aspect.toDisplayableFingerprintName(fp.name);
     } else {
-        return `${fp.name}`;
+        return fp.name;
     }
 }
 
 export function displayValue(aspect: Aspect, fp: FP): string {
     if (!!aspect.toDisplayableFingerprint) {
-        return `${aspect.toDisplayableFingerprint(fp)}`;
+        return aspect.toDisplayableFingerprint(fp);
     } else {
-        return `${fp.data}`;
+        return JSON.stringify(fp.data);
     }
 }
 
-const aspects = new Map<string, Aspect>();
-
-export function addAspect(aspect: Aspect): void {
-    aspects.set(aspect.name, aspect);
-}
-
-export function applyToAspect<T>(fp: FP, f: (aspect: Aspect, fp: FP) => T): T {
-    if (!aspects.get(fp.type || fp.name)) {
-        throw new Error(`can not lookup Aspect for ${fp.type}::${fp.name}`);
-    }
-    return f(aspects.get(fp.type), fp);
+export function aspectOf(fingerprint: FP, aspects: Aspect[]): Aspect | undefined {
+    return aspects.find(a => a.name === fingerprint.type);
 }

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -42,6 +42,7 @@ import {
 } from "../checktarget/messageMaker";
 import {
     applyTarget,
+    applyTargetBySha,
     ApplyTargetParameters,
     applyTargets,
     broadcastFingerprintMandate,
@@ -187,8 +188,9 @@ export function createPullRequestEditModeMaker(options: {
         // optional message is undefined here
         // target branch is hard-coded to master
 
-        const fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint;
+        const fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type;
         const autoMerge = _.get(options, "autoMerge") || {};
+
         return new editModes.PullRequest(
             options.branchPrefix || `apply-target-fingerprint-${Date.now()}`,
             options.title || ci.parameters.title,
@@ -280,6 +282,7 @@ function configure(
 
     sdm.addCodeTransformCommand(applyTarget(sdm, aspects, editModeMaker));
     sdm.addCodeTransformCommand(applyTargets(sdm, aspects, editModeMaker));
+    sdm.addCodeTransformCommand(applyTargetBySha(sdm, aspects, editModeMaker))
 
     sdm.addCommand(broadcastFingerprintMandate(sdm, aspects));
 

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -188,12 +188,10 @@ export function createPullRequestEditModeMaker(options: {
         // optional message is undefined here
 
         let fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type as string;
-        if (!!fingerprint) {
-            fingerprint = `[fingerprint:${fingerprint}]`;
-        } else {
+        if (!fingerprint) {
             fingerprint = ci.parameters.fingerprints as string;
             if (!!fingerprint) {
-                fingerprint = fingerprint.split(",").map(f => `[fingerprint:${f}]`).join(" ");
+                fingerprint = fingerprint.split(",").map(f => f.trim()).join(", ");
             }
         }
 

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -282,7 +282,7 @@ function configure(
 
     sdm.addCodeTransformCommand(applyTarget(sdm, aspects, editModeMaker));
     sdm.addCodeTransformCommand(applyTargets(sdm, aspects, editModeMaker));
-    sdm.addCodeTransformCommand(applyTargetBySha(sdm, aspects, editModeMaker))
+    sdm.addCodeTransformCommand(applyTargetBySha(sdm, aspects, editModeMaker));
 
     sdm.addCommand(broadcastFingerprintMandate(sdm, aspects));
 

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -180,13 +180,12 @@ export function createPullRequestEditModeMaker(options: {
         mode?: AutoMergeMode,
     },
 } = { }): EditModeMaker {
-    return ci => {
+    return (ci, p) => {
 
         // name the branch apply-target-fingerprint with a Date
         // title can be derived from ApplyTargetParameters
         // body can be derived from ApplyTargetParameters
         // optional message is undefined here
-        // target branch is hard-coded to master
 
         const fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type;
         const autoMerge = _.get(options, "autoMerge") || {};
@@ -199,7 +198,7 @@ export function createPullRequestEditModeMaker(options: {
 
 [atomist:generated]${!!fingerprint ? ` [fingerprint:${fingerprint}]` : ""}`,
             options.message,
-            ci.parameters.branch || "master",
+            ci.parameters.branch || p.id.branch,
             {
                 method: autoMerge.method || AutoMergeMethod.Squash,
                 mode: autoMerge.mode || AutoMergeMode.ApprovedReview,

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    editModes,
-    Project,
-} from "@atomist/automation-client";
+import { Project } from "@atomist/automation-client";
 import {
     AutoMerge,
     AutoMergeMethod,
@@ -26,6 +23,7 @@ import {
 import {
     ExtensionPack,
     Fingerprint,
+    formatDate,
     Goal,
     metadata,
     PushImpact,
@@ -195,14 +193,15 @@ export function createPullRequestTransformPresentation(options: PullRequestTrans
  * This allows us to better format the properties of the PullRequest as we have access to the
  * parameters instance.
  */
-class LazyPullRequest extends editModes.PullRequest {
+class LazyPullRequest {
 
     private readonly fingerprint: string;
 
+    private readonly branchName: string;
+    
     constructor(private readonly options: PullRequestTransformPresentationOptions,
                 private readonly parameters: ApplyTargetParameters,
                 private readonly project: Project) {
-        super(undefined, undefined, undefined, undefined);
 
         this.fingerprint = (this.parameters.fingerprint || this.parameters.targetfingerprint || this.parameters.type) as string;
         if (!this.fingerprint) {
@@ -211,10 +210,11 @@ class LazyPullRequest extends editModes.PullRequest {
                 this.fingerprint = this.fingerprint.split(",").map(f => f.trim()).join(", ");
             }
         }
+        this.branchName = `${this.options.branchPrefix || "apply-target-fingerprint"}-${formatDate()}`;
     }
 
     get branch(): string {
-        return `${this.options.branchPrefix || "apply-target-fingerprint"}-${Date.now()}`;
+        return this.branchName;
     }
 
     get title(): string {
@@ -225,7 +225,7 @@ class LazyPullRequest extends editModes.PullRequest {
          return this.options.body || this.parameters.body || this.title;
     }
     get message(): string {
-        return this.options.message;
+        return this.options.message || this.title;
     }
     get targetBranch(): string {
         return this.project.id.branch;

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -193,7 +193,7 @@ export function createPullRequestEditModeMaker(options: {
         } else {
             fingerprint = ci.parameters.fingerprints as string;
             if (!!fingerprint) {
-                fingerprint = fingerprint.split(",").map(f => `[fingerprint:${fingerprint}]`).join(" ");
+                fingerprint = fingerprint.split(",").map(f => `[fingerprint:${f}]`).join(" ");
             }
         }
 

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -197,7 +197,6 @@ export function createPullRequestEditModeMaker(options: {
             }
         }
 
-
         const autoMerge = _.get(options, "autoMerge") || {};
         const title = options.title || ci.parameters.title || `Apply fingerprint target (${fingerprint})`;
         const body = options.body || ci.parameters.body || title;

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -205,7 +205,7 @@ export function createPullRequestEditModeMaker(options: {
             title,
             `${body}
 
-[atomist:generated]${!!fingerprint ? ` ${fingerprint}` : ""}`,
+[atomist:generated]`,
             options.message,
             p.id.branch,
             {

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -222,7 +222,7 @@ class LazyPullRequest {
     }
 
     get body(): string {
-         return this.options.body || this.parameters.body || this.title;
+         return `${this.options.body || this.parameters.body || this.title}\n\n[atomist:generated]`;
     }
     get message(): string {
         return this.options.message || this.title;

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -187,7 +187,17 @@ export function createPullRequestEditModeMaker(options: {
         // body can be derived from ApplyTargetParameters
         // optional message is undefined here
 
-        const fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type;
+        let fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type as string;
+        if (!!fingerprint) {
+            fingerprint = `[fingerprint:${fingerprint}]`;
+        } else {
+            fingerprint = ci.parameters.fingerprints as string;
+            if (!!fingerprint) {
+                fingerprint = fingerprint.split(",").map(f => `[fingerprint:${fingerprint}]`).join(" ");
+            }
+        }
+
+
         const autoMerge = _.get(options, "autoMerge") || {};
         const title = options.title || ci.parameters.title || `Apply fingerprint target (${fingerprint})`;
         const body = options.body || ci.parameters.body || title;
@@ -196,7 +206,7 @@ export function createPullRequestEditModeMaker(options: {
             title,
             `${body}
 
-[atomist:generated]${!!fingerprint ? ` [fingerprint:${fingerprint}]` : ""}`,
+[atomist:generated]${!!fingerprint ? ` ${fingerprint}` : ""}`,
             options.message,
             p.id.branch,
             {

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -192,13 +192,13 @@ export function createPullRequestEditModeMaker(options: {
         const title = options.title || ci.parameters.title || `Apply fingerprint target (${fingerprint})`;
         const body = options.body || ci.parameters.body || title;
         return new editModes.PullRequest(
-            options.branchPrefix || `apply-target-fingerprint-${Date.now()}`,
+            `${options.branchPrefix || "apply-target-fingerprint"}-${Date.now()}`,
             title,
             `${body}
 
 [atomist:generated]${!!fingerprint ? ` [fingerprint:${fingerprint}]` : ""}`,
             options.message,
-            ci.parameters.branch || p.id.branch,
+            p.id.branch,
             {
                 method: autoMerge.method || AutoMergeMethod.Squash,
                 mode: autoMerge.mode || AutoMergeMode.ApprovedReview,

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -166,6 +166,9 @@ export interface FingerprintOptions {
 
 export const DefaultTransformPresentation: TransformPresentation<ApplyTargetParameters> = createPullRequestTransformPresentation();
 
+/**
+ * Options to configure the PullRequest creation
+ */
 export interface PullRequestTransformPresentationOptions {
     branchPrefix?: string;
     title?: string;
@@ -177,11 +180,21 @@ export interface PullRequestTransformPresentationOptions {
     };
 }
 
+/**
+ * Creates the default TransformPresentation for raising PullRequests
+ */
 export function createPullRequestTransformPresentation(options: PullRequestTransformPresentationOptions = {})
     : TransformPresentation<ApplyTargetParameters> {
     return (ci, p) => new LazyPullRequest(options, ci.parameters, p);
 }
 
+/**
+ * Lazy implementation of PullRequest to defer creation of title and body etc to when they
+ * are actually needed
+ *
+ * This allows us to better format the properties of the PullRequest as we have access to the
+ * parameters instance.
+ */
 class LazyPullRequest extends editModes.PullRequest {
 
     private readonly fingerprint: string;
@@ -205,7 +218,7 @@ class LazyPullRequest extends editModes.PullRequest {
     }
 
     get title(): string {
-        return this.options.title || this.parameters.title || `Apply fingerprint target (${this.fingerprint})`;
+        return this.options.title || this.parameters.title || `Apply target fingerprint (${this.fingerprint})`;
     }
 
     get body(): string {

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -190,11 +190,12 @@ export function createPullRequestEditModeMaker(options: {
 
         const fingerprint = ci.parameters.fingerprint || ci.parameters.targetfingerprint || ci.parameters.type;
         const autoMerge = _.get(options, "autoMerge") || {};
-
+        const title = options.title || ci.parameters.title || `Apply fingerprint target (${fingerprint})`;
+        const body = options.body || ci.parameters.body || title;
         return new editModes.PullRequest(
             options.branchPrefix || `apply-target-fingerprint-${Date.now()}`,
-            options.title || ci.parameters.title,
-            options.body || `${ci.parameters.body}
+            title,
+            `${body}
 
 [atomist:generated]${!!fingerprint ? ` [fingerprint:${fingerprint}]` : ""}`,
             options.message,
@@ -263,7 +264,7 @@ function configure(
     // set a target given using the entire JSON fingerprint payload in a parameter
     sdm.addCommand(setTargetFingerprint(aspects));
     // set a different target after noticing that a fingerprint is different from current target
-    sdm.addCommand(updateTargetFingerprint(aspects));
+    sdm.addCommand(updateTargetFingerprint(sdm, aspects));
     // Bootstrap a fingerprint target by selecting one from current project
     sdm.addCommand(selectTargetFingerprintFromCurrentProject(sdm));
     // Bootstrap a fingerprint target from project by name

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -201,7 +201,7 @@ class LazyPullRequest extends editModes.PullRequest {
     }
 
     get branch(): string {
-        return `${this.options.branchPrefix || "apply-target-fingerprint"}-${Date.now()}`
+        return `${this.options.branchPrefix || "apply-target-fingerprint"}-${Date.now()}`;
     }
 
     get title(): string {
@@ -222,7 +222,7 @@ class LazyPullRequest extends editModes.PullRequest {
         return {
             method: autoMerge.method || AutoMergeMethod.Squash,
             mode: autoMerge.mode || AutoMergeMode.ApprovedReview,
-        }
+        };
     }
 }
 

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -36,7 +36,7 @@ import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
 import { checkFingerprintTarget } from "../checktarget/callbacks";
 import {
-    IgnoreCommandRegistration,
+    ignoreCommand,
     messageMaker,
     MessageMaker,
 } from "../checktarget/messageMaker";
@@ -273,7 +273,7 @@ function configure(
     // standard actionable message embedding ApplyTargetFingerprint
     sdm.addCommand(broadcastFingerprintNudge(aspects));
 
-    sdm.addCommand(IgnoreCommandRegistration);
+    sdm.addCommand(ignoreCommand(aspects));
 
     sdm.addCommand(listFingerprintTargets(sdm));
     sdm.addCommand(listOneFingerprintTarget(sdm));

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -198,7 +198,7 @@ class LazyPullRequest {
     private readonly fingerprint: string;
 
     private readonly branchName: string;
-    
+
     constructor(private readonly options: PullRequestTransformPresentationOptions,
                 private readonly parameters: ApplyTargetParameters,
                 private readonly project: Project) {

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -44,7 +44,7 @@ import {
     Vote,
 } from "./Aspect";
 import {
-    DefaultEditModeMaker,
+    DefaultTransformPresentation,
     FingerprintImpactHandlerConfig,
     FingerprintOptions,
 } from "./fingerprintSupport";
@@ -205,7 +205,7 @@ export function fingerprintRunner(
     computer: (fingerprinters: Aspect[], p: Project) => Promise<FP[]>,
     options: FingerprintOptions & FingerprintImpactHandlerConfig = {
         aspects: [],
-        transformPresentation: DefaultEditModeMaker,
+        transformPresentation: DefaultTransformPresentation,
         messageMaker,
     }): FingerprintRunner {
 

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -209,7 +209,7 @@ export function fingerprintRunner(
         messageMaker,
     }): FingerprintRunner {
 
-    const targetDiffBallot = votes({ ...options });
+    const targetDiffBallot = votes(options);
 
     const tallyVotes = async (vts: Vote[], fingerprintHandlers: FingerprintHandler[], i: PushImpactListenerInvocation, info: MissingInfo) => {
 

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -110,5 +110,5 @@ export function prBody(vote: Vote, aspects: Aspect[]): string {
     const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`;
     const aspect = aspectOf(vote.fpTarget, aspects);
     const description = `${displayName(aspect, vote.fpTarget)} (${displayValue(aspect, vote.fpTarget)})`;
-    return `${intro}\n\n#### ${title}\n${summary}\n\n${codeBlock(description)}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
+    return `${intro}\n\n**${title}**\n${summary}\n\n${codeBlock(description)}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
 }

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -40,10 +40,10 @@ export interface GitCoordinate {
     branch?: string;
 }
 
-type MessageIdMaker = (shas: string[], coordinate: GitCoordinate, channel: string) => string;
+type MessageIdMaker = (shas: string[], coordinate: GitCoordinate) => string;
 
-export const updateableMessage: MessageIdMaker = (shas, coordinate: GitCoordinate, channel: string) => {
-    return consistentHash([...shas, channel, coordinate.owner, coordinate.repo]);
+export const updateableMessage: MessageIdMaker = (shas, coordinate: GitCoordinate) => {
+    return consistentHash([...shas, coordinate.owner, coordinate.repo]);
 };
 
 function displayFingerprint(aspect: Aspect, fp: FP): string {

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -96,6 +96,6 @@ export function prBody(vote: Vote, aspects: Aspect[]): string {
             () => vote.summary.description,
             `no summary`);
     const fingerprint = toName(vote.fpTarget.type, vote.fpTarget.name);
-    const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`
+    const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`;
     return `${intro}\n\n#### ${title}\n${description}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
 }

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -86,6 +86,12 @@ export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
     }
 }
 
+export function prBodyFromFingerprint(fp: FP, aspects: Aspect[]): string {
+    const fingerprint = toName(fp.type, fp.name);
+    const intro = `Apply target fingerprint ${codeLine(fingerprint)}`;
+    return `${intro}\n\n[fingerprint:${fingerprint}=${fp.sha}]`;
+}
+
 export function prBody(vote: Vote, aspects: Aspect[]): string {
     const title: string =
         orDefault(

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -18,6 +18,8 @@ import { logger } from "@atomist/automation-client";
 import {
     consistentHash,
 } from "@atomist/clj-editors";
+import { codeLine } from "@atomist/slack-messages";
+import { toName } from "../adhoc/preferences";
 import {
     Aspect,
     Diff,
@@ -93,6 +95,7 @@ export function prBody(vote: Vote, aspects: Aspect[]): string {
         orDefault(
             () => vote.summary.description,
             `no summary`);
-
-    return `#### ${title}\n${description}`;
+    const fingerprint = toName(vote.fpTarget.type, vote.fpTarget.name);
+    const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`
+    return `${intro}\n\n#### ${title}\n${description}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
 }

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -83,7 +83,7 @@ export function getDiffSummary(diff: Diff, target: FP, aspect: Aspect): undefine
 export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
     const aspect = aspectOf(fp, aspects);
     if (!!aspect) {
-        return `Apply target fingerprint ${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
+        return `Apply target fingerprint ${displayName(aspect, fp)}`;
     } else {
         return `Apply target fingerprint ${fp.name}`;
     }
@@ -92,7 +92,7 @@ export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
 export function prBodyFromFingerprint(fp: FP, aspects: Aspect[]): string {
     const aspect = aspectOf(fp, aspects);
     const fingerprint = toName(fp.type, fp.name);
-    const intro = `Apply target fingerprint ${codeLine(fingerprint)}`;
+    const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`;
     const description = `${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
     return `${intro}\n\n${codeBlock(description)}\n\n[fingerprint:${fingerprint}=${fp.sha}]`;
 }
@@ -102,11 +102,13 @@ export function prBody(vote: Vote, aspects: Aspect[]): string {
         orDefault(
             () => vote.summary.title,
             applyFingerprintTitle(vote.fpTarget, aspects));
-    const description: string =
+    const summary: string =
         orDefault(
             () => vote.summary.description,
             `no summary`);
     const fingerprint = toName(vote.fpTarget.type, vote.fpTarget.name);
     const intro = `Apply target fingerprint ${codeLine(fingerprint)}:`;
-    return `${intro}\n\n#### ${title}\n${description}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
+    const aspect = aspectOf(vote.fpTarget, aspects);
+    const description = `${displayName(aspect, vote.fpTarget)} (${displayValue(aspect, vote.fpTarget)})`;
+    return `${intro}\n\n#### ${title}\n${summary}\n\n${codeBlock(description)}\n\n[fingerprint:${fingerprint}=${vote.fpTarget.sha}]`;
 }

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -80,9 +80,9 @@ export function getDiffSummary(diff: Diff, target: FP, aspect: Aspect): undefine
 export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
     const aspect = aspectOf(fp, aspects);
     if (!!aspect) {
-        return `Apply fingerprint ${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
+        return `Apply target fingerprint ${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
     } else {
-        return `Apply fingerprint ${fp.name}`;
+        return `Apply target fingerprint ${fp.name}`;
     }
 }
 

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -18,7 +18,10 @@ import { logger } from "@atomist/automation-client";
 import {
     consistentHash,
 } from "@atomist/clj-editors";
-import { codeLine } from "@atomist/slack-messages";
+import {
+    codeBlock,
+    codeLine,
+} from "@atomist/slack-messages";
 import { toName } from "../adhoc/preferences";
 import {
     Aspect,
@@ -87,9 +90,11 @@ export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
 }
 
 export function prBodyFromFingerprint(fp: FP, aspects: Aspect[]): string {
+    const aspect = aspectOf(fp, aspects);
     const fingerprint = toName(fp.type, fp.name);
     const intro = `Apply target fingerprint ${codeLine(fingerprint)}`;
-    return `${intro}\n\n[fingerprint:${fingerprint}=${fp.sha}]`;
+    const description = `${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
+    return `${intro}\n\n${codeBlock(description)}\n\n[fingerprint:${fingerprint}=${fp.sha}]`;
 }
 
 export function prBody(vote: Vote, aspects: Aspect[]): string {

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -26,7 +26,7 @@ import {
     Vote,
 } from "../machine/Aspect";
 import {
-    applyToAspect,
+    aspectOf,
     displayName,
     displayValue,
 } from "../machine/Aspects";
@@ -75,19 +75,20 @@ export function getDiffSummary(diff: Diff, target: FP, aspect: Aspect): undefine
     return undefined;
 }
 
-export function applyFingerprintTitle(fp: FP): string {
-    try {
-        return `Apply fingerprint ${applyToAspect(fp, displayName)} (${applyToAspect(fp, displayValue)})`;
-    } catch (ex) {
+export function applyFingerprintTitle(fp: FP, aspects: Aspect[]): string {
+    const aspect = aspectOf(fp, aspects);
+    if (!!aspect) {
+        return `Apply fingerprint ${displayName(aspect, fp)} (${displayValue(aspect, fp)})`;
+    } else {
         return `Apply fingerprint ${fp.name}`;
     }
 }
 
-export function prBody(vote: Vote): string {
+export function prBody(vote: Vote, aspects: Aspect[]): string {
     const title: string =
         orDefault(
             () => vote.summary.title,
-            applyFingerprintTitle(vote.fpTarget));
+            applyFingerprintTitle(vote.fpTarget, aspects));
     const description: string =
         orDefault(
             () => vote.summary.description,

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,9 +242,9 @@
       }
     },
     "@atomist/sdm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.6.0.tgz",
-      "integrity": "sha512-EB4D5WAMkx0ZQ3eS+/gpTUrM1O6VdAT+OYxxLKGG6QcxCgu+SVssxVNpy8wzVT6y02DJU/RieH3PKGph/Lv2oA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.6.1.tgz",
+      "integrity": "sha512-25uxNtbsT+EQvunGtlY4nZUq6CeDWUEGwfTipJiah6syXe0VQxXdXk7WfuPSNvS6+aAYppX/t95mFRHed1ns6g==",
       "dev": true,
       "requires": {
         "@types/cron": "^1.7.1",
@@ -265,7 +265,7 @@
         "fs-extra": "^8.0.1",
         "js-yaml": "^3.13.1",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "sha-regex": "^1.0.4",
         "sprintf-js": "^1.1.2",
@@ -284,34 +284,75 @@
       }
     },
     "@atomist/sdm-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.6.0.tgz",
-      "integrity": "sha512-bqwz+Nh2TZckN45xZBlNVUm3NG358OIqvibjCyhZJW6IwcRnLp0koD5gheM2uteFbmxfYVpiF3vQJ6+Bn2RH7w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.6.1.tgz",
+      "integrity": "sha512-oVLnKkRVsrt4pMrs/N5+ixK9PxfkxXPRdjE34e0gkBWIOwGAlwBaH1zm07YrB919GSeXTZ/oeRuX/KfyBesmcw==",
       "dev": true,
       "requires": {
         "@kubernetes/client-node": "^0.10.2",
-        "@octokit/rest": "^16.3.0",
+        "@octokit/rest": "^16.28.3",
         "@types/glob": "^7.1.1",
-        "@types/proper-lockfile": "^3.0.0",
+        "@types/proper-lockfile": "^4.1.0",
         "@types/request": "^2.48.1",
-        "@types/retry": "^0.10.2",
-        "app-root-path": "^2.1.0",
+        "@types/retry": "^0.12.0",
+        "app-root-path": "^2.2.1",
         "axios": "^0.19.0",
-        "chalk": "^2.4.1",
-        "fs-extra": "^7.0.0",
-        "glob": "^7.1.3",
+        "chalk": "^2.4.2",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.4",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.10",
-        "moment": "^2.23.0",
-        "moment-duration-format": "2.2.2",
+        "lodash": "^4.17.14",
+        "moment": "^2.24.0",
+        "moment-duration-format": "2.3.2",
         "promise-retry": "^1.1.1",
-        "proper-lockfile": "^3.2.0",
+        "proper-lockfile": "^4.1.1",
         "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "tmp-promise": "^1.0.4",
-        "ts-essentials": "^1.0.2"
+        "tmp-promise": "^2.0.2",
+        "ts-essentials": "^2.0.12"
       },
       "dependencies": {
+        "@octokit/request": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.0.2.tgz",
+          "integrity": "sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^5.1.0",
+            "@octokit/request-error": "^1.0.1",
+            "deprecation": "^2.0.0",
+            "is-plain-object": "^3.0.0",
+            "node-fetch": "^2.3.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^3.0.0"
+          }
+        },
+        "@octokit/rest": {
+          "version": "16.28.7",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.7.tgz",
+          "integrity": "sha512-cznFSLEhh22XD3XeqJw51OLSfyL2fcFKUO+v2Ep9MTAFfFLS1cK1Zwd1yEgQJmJoDnj4/vv3+fGGZweG+xsbIA==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "^5.0.0",
+            "@octokit/request-error": "^1.0.2",
+            "atob-lite": "^2.0.0",
+            "before-after-hook": "^2.0.0",
+            "btoa-lite": "^1.0.0",
+            "deprecation": "^2.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^3.0.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -320,6 +361,12 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
+        },
+        "before-after-hook": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+          "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -332,21 +379,10 @@
             "supports-color": "^5.3.0"
           }
         },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
         "proper-lockfile": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
-          "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+          "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -363,23 +399,13 @@
             "has-flag": "^3.0.0"
           }
         },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+        "universal-user-agent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-3.0.0.tgz",
+          "integrity": "sha512-T3siHThqoj5X0benA5H0qcDnrKGXzU8TKoX15x/tQHw1hQBvIEBHjxQ2klizYsqBOO/Q+WuxoQUihadeeqDnoA==",
           "dev": true,
           "requires": {
-            "rimraf": "^2.6.3"
-          }
-        },
-        "tmp-promise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.1.0.tgz",
-          "integrity": "sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.0",
-            "tmp": "0.1.0"
+            "os-name": "^3.0.0"
           }
         }
       }
@@ -711,9 +737,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
-          "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==",
+          "version": "10.14.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+          "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==",
           "dev": true
         },
         "ws": {
@@ -1529,15 +1555,6 @@
       "integrity": "sha512-60LC501bQRN9/3yfVaEEMd7IndaufffL56PBRAejPpUrY304Ps1jfnjNqPw5jmM5R8JHWiKBAe5IHzNcPV41AA==",
       "dev": true
     },
-    "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/fs-extra": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
@@ -1728,10 +1745,13 @@
       }
     },
     "@types/proper-lockfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-3.0.1.tgz",
-      "integrity": "sha512-ODOjqxmaNs0Zkij+BJovsNJRSX7BJrr681o8ZnNTNIcTermvVFzLpz/XFtfg3vNrlPVTJY1l4e9h2LvHoxC1lg==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.0.tgz",
+      "integrity": "sha512-Jlu4JBbhU29/GP3mniXWOneMWmLXKc6f0VklcXU9RIXpDP5JksYBG4pm/IOjxf4LHD/BvCUT9YGF4OnVh+hZJA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -1740,15 +1760,28 @@
       "dev": true
     },
     "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
+      "integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
       "dev": true,
       "requires": {
         "@types/caseless": "*",
-        "@types/form-data": "*",
         "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/retry": {
@@ -2910,12 +2943,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -8179,9 +8206,9 @@
       "dev": true
     },
     "moment-duration-format": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
-      "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==",
       "dev": true
     },
     "moment-timezone": {
@@ -9793,9 +9820,9 @@
       "dev": true
     },
     "sha-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sha-regex/-/sha-regex-1.0.5.tgz",
-      "integrity": "sha512-b5Tg58fcUYBXgUU2a1Q4Jl1b5VgtXQhTwJZDCxoKtCwGKJSuAbUyPwB7V/XzF5nrn3I43dD2YDYdt4neoo2coA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/sha-regex/-/sha-regex-1.0.7.tgz",
+      "integrity": "sha512-VN8lub9pYXqFi/ibV1lE4CB+aQLxSaLIpT0XWAZ2pV8U0PH9/NH5M2uO62WKb1gayf8sS/KbtZv0VOdQhnGnmA==",
       "dev": true
     },
     "sha.js": {
@@ -10605,9 +10632,9 @@
       "dev": true
     },
     "ts-essentials": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
-      "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
       "dev": true
     },
     "ts-invariant": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "@atomist/automation-client": ">=1.6.0",
-    "@atomist/sdm": ">=1.6.0",
-    "@atomist/sdm-core": ">=1.6.0"
+    "@atomist/sdm": "^1.6.1",
+    "@atomist/sdm-core": "^1.6.1"
   },
   "devDependencies": {
     "@atomist/automation-client": "^1.6.2",
-    "@atomist/sdm": "^1.6.0",
-    "@atomist/sdm-core": "^1.6.0",
+    "@atomist/sdm": "^1.6.1",
+    "@atomist/sdm-core": "^1.6.1",
     "@types/lodash": "^4.14.136",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.1",

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -33,6 +33,7 @@ import {
     PushTest,
     SoftwareDeliveryMachine,
     SoftwareDeliveryMachineConfiguration,
+    TransformPresentation,
     whenPushSatisfies,
 } from "@atomist/sdm";
 import {
@@ -49,7 +50,7 @@ import { Backpack } from "../lib/fingerprints/backpack";
 import {
     JsonFile,
 } from "../lib/fingerprints/jsonFiles";
-import { EditModeMaker } from "../lib/machine/fingerprintSupport";
+import { ApplyTargetParameters } from "../lib/handlers/commands/applyFingerprint";
 
 const IsNpm: PushTest = pushTest(`contains package.json file`, async pci =>
     !!(await pci.project.getFile("package.json")),
@@ -102,7 +103,7 @@ const FingerprintingGoals: Goals = goals("check fingerprints")
     .plan(pushImpact, // complianceGoal
     );
 
-export const AutoApproveEditModeMaker: EditModeMaker = (ci, p) => {
+export const AutoApproveEditModeMaker: TransformPresentation<ApplyTargetParameters> = (ci, p) => {
     // name the branch apply-target-fingerprint with a Date
     // title can be derived from ApplyTargetParameters
     // body can be derived from ApplyTargetParameters

--- a/test/fingerprints/atomicAspect.test.ts
+++ b/test/fingerprints/atomicAspect.test.ts
@@ -25,7 +25,6 @@ import {
     Aspect,
     ExtractFingerprint,
 } from "../../lib/machine/Aspect";
-import { addAspect } from "../../lib/machine/Aspects";
 import { atomicAspect } from "../../lib/machine/AtomicAspect";
 
 describe("atomicAspect", () => {
@@ -121,8 +120,6 @@ describe("atomicAspect", () => {
                 return true;
             },
         };
-        addAspect(f1);
-        addAspect(f2);
 
         // create Atomic Aspect
         const aspect = atomicAspect(


### PR DESCRIPTION
* Remove the usage of a global `aspects` const
* Fix semantics around failed or aborted code transforms
* Add command to apply a fingerprint by type::name and sha to one project
* Fix access to slack user so that commands work from the web
* Fix Apply All to not run `aspect.apply` with `Promise.all` as that can't work