### PR TITLE
Update Aspect/Fingerprint signatures

### DIFF
--- a/lib/adhoc/fingerprints.ts
+++ b/lib/adhoc/fingerprints.ts
@@ -24,6 +24,7 @@ import {
 } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
 import { FP } from "../machine/Aspect";
+import { promiseAllSeq } from "../support/util";
 import {
     AddFingerprints,
     FindOtherRepos,
@@ -85,7 +86,7 @@ export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, 
         );
 
         await partitionByFeature(fps, async partitioned => {
-            await Promise.all(partitioned.map(async ({ type, additions }) => {
+            await promiseAllSeq(partitioned.map(async ({ type, additions }) => {
                 logger.info(`Upload ${additions.length} fingerprints of type ${type}`);
                 await i.context.graphClient.mutate<AddFingerprints.Mutation, AddFingerprints.Variables>(
                     {

--- a/lib/adhoc/fingerprints.ts
+++ b/lib/adhoc/fingerprints.ts
@@ -24,7 +24,6 @@ import {
 } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
 import { FP } from "../machine/Aspect";
-import { promiseAllSeq } from "../support/util";
 import {
     AddFingerprints,
     FindOtherRepos,
@@ -86,7 +85,7 @@ export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, 
         );
 
         await partitionByFeature(fps, async partitioned => {
-            await promiseAllSeq(partitioned.map(async ({ type, additions }) => {
+            await Promise.all(partitioned.map(async ({ type, additions }) => {
                 logger.info(`Upload ${additions.length} fingerprints of type ${type}`);
                 await i.context.graphClient.mutate<AddFingerprints.Mutation, AddFingerprints.Variables>(
                     {

--- a/lib/adhoc/fingerprints.ts
+++ b/lib/adhoc/fingerprints.ts
@@ -85,7 +85,7 @@ export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, 
         );
 
         await partitionByFeature(fps, async partitioned => {
-            await Promise.all(partitioned.map(async ({ type, additions }) => {
+            for (const { type, additions } of partitioned) {
                 logger.info(`Upload ${additions.length} fingerprints of type ${type}`);
                 await i.context.graphClient.mutate<AddFingerprints.Mutation, AddFingerprints.Variables>(
                     {
@@ -100,7 +100,7 @@ export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, 
                         },
                     },
                 );
-            }));
+            }
         });
     } catch (ex) {
         logger.error(`Error sending fingerprints: ${ex.message}`);

--- a/lib/adhoc/fingerprints.ts
+++ b/lib/adhoc/fingerprints.ts
@@ -19,9 +19,7 @@ import {
     logger,
     QueryNoCacheOptions,
 } from "@atomist/automation-client";
-import {
-    partitionByFeature,
-} from "@atomist/clj-editors";
+import { partitionByFeature } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
 import { FP } from "../machine/Aspect";
 import {

--- a/lib/fingerprints/backpack.ts
+++ b/lib/fingerprints/backpack.ts
@@ -41,6 +41,7 @@ export const backpackFingerprint: ExtractFingerprint = async p => {
         const data: any = _.get(packagejson, "backpack-react-scripts.externals", "");
 
         const fp: FP = {
+            type: Backpack.name,
             name: Backpack.name,
             abbreviation: "backpack",
             version: "0.0.1",

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -76,18 +76,18 @@ export function createFilesFingerprint(type: string,
     };
 }
 
-export const applyFileFingerprint: ApplyFingerprint<FileFingerprintData> = async (p, fp) => {
+export const applyFileFingerprint: ApplyFingerprint<FileFingerprintData> = async (p, papi) => {
+    const fp = papi.parameters.fp;
     const file = await p.getFile(fp.data.filename);
 
     if (file) {
         logger.info("Update content on an existing file");
         await file.setContent(fp.data.content);
-        return true;
     } else {
         logger.info("Creating new file '%s'", fp.data.filename);
         await p.addFile(fp.data.filename, fp.data.content);
-        return true;
     }
+    return p;
 };
 
 export const JsonFile: Aspect<FileFingerprintData> = {

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -51,30 +51,26 @@ export function createFilesFingerprint(type: string,
                                        ...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return async p => {
         const fps: FileFingerprint[] = [];
-        await Promise.all(
-            filenames.map(async filename => {
-                    const file = await p.getFile(filename);
-
-                    if (file) {
-                        const content = await file.getContent();
-                        const canonicalized = canonicalize(content);
-                        fps.push(
-                            {
-                                type,
-                                name: filename,
-                                abbreviation: `file-${filename}`,
-                                version: "0.0.1",
-                                data: {
-                                    content,
-                                    filename,
-                                },
-                                sha: sha256(JSON.stringify(canonicalized)),
-                            },
-                        );
-                    }
-                },
-            ));
-
+        for (const filename of filenames) {
+            const file = await p.getFile(filename);
+            if (file) {
+                const content = await file.getContent();
+                const canonicalized = canonicalize(content);
+                fps.push(
+                    {
+                        type,
+                        name: filename,
+                        abbreviation: `file-${filename}`,
+                        version: "0.0.1",
+                        data: {
+                            content,
+                            filename,
+                        },
+                        sha: sha256(JSON.stringify(canonicalized)),
+                    },
+                );
+            }
+        }
         return fps;
     };
 }

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -17,7 +17,8 @@
 import { logger } from "@atomist/automation-client";
 import {
     ApplyFingerprint,
-    ExtractFingerprint, FP,
+    ExtractFingerprint,
+    FP,
     sha256,
 } from "../..";
 import { Aspect } from "../machine/Aspect";
@@ -50,7 +51,7 @@ export function createFilesFingerprint(type: string,
                                        canonicalize: (content: string) => any,
                                        ...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return async p => {
-        const fps: FileFingerprint[] = [];
+        const fps: Array<FP<FileFingerprintData>> = [];
         for (const filename of filenames) {
             const file = await p.getFile(filename);
             if (file) {

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -21,7 +21,6 @@ import {
     sha256,
 } from "../..";
 import { Aspect } from "../machine/Aspect";
-import { promiseAllSeq } from "../support/util";
 
 export interface FileFingerprintData {
     filename: string;
@@ -51,8 +50,8 @@ export function createFilesFingerprint(type: string,
                                        canonicalize: (content: string) => any,
                                        ...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return async p => {
-        const fps: Array<FP<FileFingerprintData>> = [];
-        await promiseAllSeq(
+        const fps: FileFingerprint[] = [];
+        await Promise.all(
             filenames.map(async filename => {
                     const file = await p.getFile(filename);
 

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -21,6 +21,7 @@ import {
     sha256,
 } from "../..";
 import { Aspect } from "../machine/Aspect";
+import { promiseAllSeq } from "../support/util";
 
 export interface FileFingerprintData {
     filename: string;
@@ -51,7 +52,7 @@ export function createFilesFingerprint(type: string,
                                        ...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return async p => {
         const fps: Array<FP<FileFingerprintData>> = [];
-        await Promise.all(
+        await promiseAllSeq(
             filenames.map(async filename => {
                     const file = await p.getFile(filename);
 

--- a/lib/fingerprints/maven.ts
+++ b/lib/fingerprints/maven.ts
@@ -27,7 +27,7 @@ export const MavenDeps: Aspect = {
     displayName: "Maven dependencies",
     name: "maven-project-deps",
     extract: p => mavenDeps((p as LocalProject).baseDir),
-    apply: (p, fp) => applyFingerprint((p as LocalProject).baseDir, fp),
+    apply: (p, papi) => applyFingerprint((p as LocalProject).baseDir, papi.parameters.fp),
     toDisplayableFingerprint: fp => fp.name,
     summary: renderProjectLibDiff,
 };
@@ -36,7 +36,7 @@ export const MavenCoordinates: Aspect = {
     displayName: "Maven coordinates",
     name: "maven-project-coordinates",
     extract: p => mavenCoordinates((p as LocalProject).baseDir),
-    apply: (p, fp) => applyFingerprint((p as LocalProject).baseDir, fp),
+    apply: (p, papi) => applyFingerprint((p as LocalProject).baseDir, papi.parameters.fp),
     toDisplayableFingerprint: fp => fp.name,
     summary: diff => {
         return {

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -42,6 +42,7 @@ import {
     DefaultTargetDiffHandler,
     diffOnlyHandler,
 } from "../machine/fingerprintSupport";
+import { promiseAllSeq } from "../support/util";
 
 /**
  * [lib, version]
@@ -205,7 +206,7 @@ export const NpmCoordinates: Aspect = {
     workflows: [
         diffOnlyHandler(
             (ctx, diffs) => {
-                return Promise.all(_.map(diffs, diff => {
+                return promiseAllSeq(_.map(diffs, async diff => {
                     if (diff.channel) {
                         return setNewTargetFingerprint(
                             ctx.context,

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -37,6 +37,7 @@ import { setNewTargetFingerprint } from "../handlers/commands/updateTarget";
 import {
     Aspect,
     DiffSummaryFingerprint,
+    Vote,
 } from "../machine/Aspect";
 import {
     DefaultTargetDiffHandler,
@@ -204,18 +205,20 @@ export const NpmCoordinates: Aspect = {
     toDisplayableFingerprint: fp => fp.data,
     workflows: [
         diffOnlyHandler(
-            (ctx, diffs) => {
-                return Promise.all(_.map(diffs, diff => {
+            async (ctx, diffs) => {
+                const votes: Vote[] = [];
+                for (const diff of diffs) {
                     if (diff.channel) {
-                        return setNewTargetFingerprint(
+                        votes.push(await setNewTargetFingerprint(
                             ctx.context,
                             NpmDeps,
                             createNpmDepFingerprint(diff.to.data.name, diff.to.data.version),
-                            diff.channel);
+                            diff.channel));
                     } else {
-                        return { abstain: true };
+                        votes.push({ abstain: true });
                     }
-                }));
+                }
+                return votes;
             },
         ),
     ],

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -42,7 +42,6 @@ import {
     DefaultTargetDiffHandler,
     diffOnlyHandler,
 } from "../machine/fingerprintSupport";
-import { promiseAllSeq } from "../support/util";
 
 /**
  * [lib, version]
@@ -206,7 +205,7 @@ export const NpmCoordinates: Aspect = {
     workflows: [
         diffOnlyHandler(
             (ctx, diffs) => {
-                return promiseAllSeq(_.map(diffs, async diff => {
+                return Promise.all(_.map(diffs, diff => {
                     if (diff.channel) {
                         return setNewTargetFingerprint(
                             ctx.context,

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -26,7 +26,7 @@ import {
     bold,
     codeLine,
 } from "@atomist/slack-messages";
-import _ = require("lodash");
+import * as _ from "lodash";
 import {
     ApplyFingerprint,
     ExtractFingerprint,

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -26,7 +26,6 @@ import {
     bold,
     codeLine,
 } from "@atomist/slack-messages";
-import _ = require("lodash");
 import {
     ApplyFingerprint,
     ExtractFingerprint,
@@ -43,6 +42,7 @@ import {
     DefaultTargetDiffHandler,
     diffOnlyHandler,
 } from "../machine/fingerprintSupport";
+import _ = require("lodash");
 
 /**
  * [lib, version]

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -26,6 +26,7 @@ import {
     bold,
     codeLine,
 } from "@atomist/slack-messages";
+import _ = require("lodash");
 import {
     ApplyFingerprint,
     ExtractFingerprint,
@@ -42,7 +43,6 @@ import {
     DefaultTargetDiffHandler,
     diffOnlyHandler,
 } from "../machine/fingerprintSupport";
-import _ = require("lodash");
 
 /**
  * [lib, version]

--- a/lib/fingerprints/virtual-project/fileNamesVirtualProjectFinder.ts
+++ b/lib/fingerprints/virtual-project/fileNamesVirtualProjectFinder.ts
@@ -18,14 +18,14 @@ import {
     logger,
     projectUtils,
 } from "@atomist/automation-client";
+
+import * as _ from "lodash";
+import * as pathlib from "path";
 import {
     RootIsOnlyProject,
     VirtualProjectFinder,
     VirtualProjectStatus,
 } from "./VirtualProjectFinder";
-
-import * as _ from "lodash";
-import * as pathlib from "path";
 
 /**
  * Identify directories in which any file matching any glob pattern is found as virtual projects.

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -15,6 +15,7 @@
  */
 
 import { Project } from "@atomist/automation-client";
+// tslint:disable:deprecation
 import { chainTransforms } from "@atomist/sdm";
 import * as _ from "lodash";
 import {

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -15,22 +15,18 @@
  */
 
 import { Project } from "@atomist/automation-client";
+import * as _ from "lodash";
 import {
     ApplyFingerprint,
     Aspect,
     ExtractFingerprint,
     FP,
 } from "../../machine/Aspect";
+import { localProjectUnder } from "./support/localProjectUnder";
 import {
     VirtualProjectFinder,
     VirtualProjectStatus,
 } from "./VirtualProjectFinder";
-import * as _ from "lodash";
-import {
-    AtomicAspect,
-    isAtomicAspect,
-} from "../../machine/AtomicAspect";
-import { localProjectUnder } from "./support/localProjectUnder";
 
 /**
  * Make this aspect work with virtual projects as found by the given

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -25,8 +25,8 @@ import {
     VirtualProjectFinder,
     VirtualProjectStatus,
 } from "./VirtualProjectFinder";
-
 import * as _ from "lodash";
+import { promiseAllSeq } from "../../support/util";
 import { localProjectUnder } from "./support/localProjectUnder";
 
 /**
@@ -58,7 +58,7 @@ export function makeExtractorVirtualProjectAware(ef: ExtractFingerprint,
                                                  virtualProjectFinder: VirtualProjectFinder): (p: Project) => Promise<FP[]> {
     return async p => {
         const virtualProjects = await virtualProjectsIn(p, virtualProjectFinder);
-        return _.flatten(await Promise.all(virtualProjects.map(vp =>
+        return _.flatten(await promiseAllSeq(virtualProjects.map(vp =>
                 extractFrom(ef, vp)
                     .then(extracted =>
                         extracted
@@ -77,7 +77,7 @@ export function makeExtractorVirtualProjectAware(ef: ExtractFingerprint,
 async function virtualProjectsIn(p: Project, virtualProjectFinder: VirtualProjectFinder): Promise<Project[]> {
     const virtualProjectInfo = await virtualProjectFinder.findVirtualProjectInfo(p);
     if (virtualProjectInfo.status === VirtualProjectStatus.IdentifiedPaths) {
-        return Promise.all(virtualProjectInfo.virtualProjects.map(sp => localProjectUnder(p, sp.path)));
+        return promiseAllSeq(virtualProjectInfo.virtualProjects.map(sp => localProjectUnder(p, sp.path)));
     }
     return [p];
 }
@@ -93,7 +93,7 @@ export function makeApplyVirtualProjectAware(af: ApplyFingerprint,
                                              virtualProjectFinder: VirtualProjectFinder): ApplyFingerprint {
     return async (p, fp) => {
         const virtualProjects = await virtualProjectsIn(p, virtualProjectFinder);
-        const results = await Promise.all(virtualProjects.map(vp => af(vp, fp)));
+        const results = await promiseAllSeq(virtualProjects.map(vp => af(vp, fp)));
         return !results.includes(false);
     };
 }

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -15,6 +15,7 @@
  */
 
 import { Project } from "@atomist/automation-client";
+import { chainTransforms } from "@atomist/sdm";
 import * as _ from "lodash";
 import {
     ApplyFingerprint,
@@ -90,9 +91,8 @@ async function extractFrom(ef: ExtractFingerprint, p: Project): Promise<FP[]> {
 
 export function makeApplyVirtualProjectAware(af: ApplyFingerprint,
                                              virtualProjectFinder: VirtualProjectFinder): ApplyFingerprint {
-    return async (p, fp) => {
+    return async (p, papi) => {
         const virtualProjects = await virtualProjectsIn(p, virtualProjectFinder);
-        const results = await Promise.all(virtualProjects.map(vp => af(vp, fp)));
-        return !results.includes(false);
+        return chainTransforms(...virtualProjects.map(v => (async (vp: any, vpapi: any) => af(v, vpapi))))(p, papi, papi.parameters);
     };
 }

--- a/lib/handlers/commands/applyFingerprint.ts
+++ b/lib/handlers/commands/applyFingerprint.ts
@@ -68,7 +68,7 @@ async function pushFingerprint(
 
     const aspect = aspectOf(fp, aspects);
     if (!!aspect && !!aspect.apply) {
-        return await aspect.apply(p, { ...papi, parameters: { fp } });
+        return aspect.apply(p, { ...papi, parameters: { fp } });
     }
 }
 

--- a/lib/handlers/commands/showTargets.ts
+++ b/lib/handlers/commands/showTargets.ts
@@ -22,9 +22,7 @@ import {
     SlackFileMessage,
 } from "@atomist/automation-client";
 
-import {
-    renderData,
-} from "@atomist/clj-editors";
+import { renderData } from "@atomist/clj-editors";
 import {
     CommandHandlerRegistration,
     slackQuestionMessage,

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -19,11 +19,11 @@ import {
     Project,
 } from "@atomist/automation-client";
 import { SdmContext } from "@atomist/sdm";
+
+import * as _ from "lodash";
 import { GitCoordinate } from "../support/messages";
 import { GetFpTargets } from "../typings/types";
 import { Ideal } from "./Ideal";
-
-import * as _ from "lodash";
 
 /**
  * Fingerprint interface. An Aspect can emit zero or more fingerprints,

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -18,7 +18,10 @@ import {
     HandlerContext,
     Project,
 } from "@atomist/automation-client";
-import { SdmContext } from "@atomist/sdm";
+import {
+    CodeTransform,
+    SdmContext,
+} from "@atomist/sdm";
 
 import * as _ from "lodash";
 import { GitCoordinate } from "../support/messages";
@@ -83,7 +86,7 @@ export type FingerprintSelector = (fingerprint: FP) => boolean;
 /**
  * Apply the given fingerprint to the project
  */
-export type ApplyFingerprint<DATA = any> = (p: Project, fp: FP<DATA>) => Promise<boolean>;
+export type ApplyFingerprint<DATA = any> = CodeTransform<{ fp: FP<DATA> }>;
 
 export interface DiffSummary {
     title: string;

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -31,13 +31,12 @@ import * as _ from "lodash";
  * @param DATA type parameter for data
  */
 export interface FP<DATA = any> {
-    type?: string;
+    type: string;
     name: string;
     sha: string;
     data: DATA;
     version?: string;
     abbreviation?: string;
-
     /**
      * Path within the repository. Undefined means root.
      */
@@ -234,7 +233,7 @@ export interface DiffContext extends Diff {
     targets: GetFpTargets.Query;
 }
 
-export type FingerprintDiffHandler = (context: SdmContext, diff: DiffContext, aspect: Aspect) => Promise<Vote>;
+export type FingerprintDiffHandler = (context: SdmContext, diff: DiffContext[], aspect: Aspect) => Promise<Vote[]>;
 
 /**
  * Handles differences between fingerprints across pushes and between targets.

--- a/lib/machine/AtomicAspect.ts
+++ b/lib/machine/AtomicAspect.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {sha256} from "@atomist/clj-editors";
+import { sha256 } from "@atomist/clj-editors";
 import {
     ApplyFingerprint,
     Aspect,

--- a/lib/machine/AtomicAspect.ts
+++ b/lib/machine/AtomicAspect.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { sha256 } from "@atomist/clj-editors";
+// tslint:disable:deprecation
 import { chainTransforms } from "@atomist/sdm";
+import { sha256 } from "../..";
 import {
     ApplyFingerprint,
     Aspect,

--- a/lib/machine/AtomicAspect.ts
+++ b/lib/machine/AtomicAspect.ts
@@ -58,6 +58,7 @@ function createCompositeFingerprint(prefix: string, fingerprints: FP[]): FP {
     return fingerprints.length === 0 ?
         undefined :
         {
+            type: prefix + fingerprints.map(fp => fp.type).join("&"),
             name: prefix + fingerprints.map(fp => fp.name).join("&"),
             version: "0.1.0",
             abbreviation: prefix,

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -63,7 +63,6 @@ import {
     setTargetFingerprintFromLatestMaster,
     updateTargetFingerprint,
 } from "../handlers/commands/updateTarget";
-import { promiseAllSeq } from "../support/util";
 import {
     Aspect,
     FingerprintDiffHandler,
@@ -104,14 +103,16 @@ export const DefaultTargetDiffHandler: FingerprintDiffHandler =
     async (ctx, diffs, aspect) => {
         const abs = _.filter(diffs, diff => !diff.from);
         return [
-            ... await promiseAllSeq(
+            ... await Promise.all(
                     _.map (
                         _.difference(diffs, abs), diff => checkFingerprintTarget(
                             ctx.context,
                             diff,
                             aspect,
                             async () => diff.targets ))),
-            ... _.map(abs, () => ({abstain: true})),
+            ... _.map(abs, () => {
+                return {abstain: true};
+             }),
         ];
     };
 
@@ -125,7 +126,9 @@ export function diffOnlyHandler(handler: FingerprintDiffHandler): FingerprintDif
         const toDiff = _.filter(diffs, diff => diff.from && diff.to.sha !== diff.from.sha);
         return [
             ... await handler(context, toDiff, aspect),
-            ... _.map(_.difference(diffs, toDiff), () => ({abstain: true})),
+            ... _.map(_.difference(diffs, toDiff), () => {
+                return {abstain: true};
+             }),
         ];
     };
 }

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -63,6 +63,7 @@ import {
     setTargetFingerprintFromLatestMaster,
     updateTargetFingerprint,
 } from "../handlers/commands/updateTarget";
+import { promiseAllSeq } from "../support/util";
 import {
     Aspect,
     FingerprintDiffHandler,
@@ -103,16 +104,14 @@ export const DefaultTargetDiffHandler: FingerprintDiffHandler =
     async (ctx, diffs, aspect) => {
         const abs = _.filter(diffs, diff => !diff.from);
         return [
-            ... await Promise.all(
+            ... await promiseAllSeq(
                     _.map (
                         _.difference(diffs, abs), diff => checkFingerprintTarget(
                             ctx.context,
                             diff,
                             aspect,
                             async () => diff.targets ))),
-            ... _.map(abs, () => {
-                return {abstain: true};
-             }),
+            ... _.map(abs, () => ({abstain: true})),
         ];
     };
 
@@ -126,9 +125,7 @@ export function diffOnlyHandler(handler: FingerprintDiffHandler): FingerprintDif
         const toDiff = _.filter(diffs, diff => diff.from && diff.to.sha !== diff.from.sha);
         return [
             ... await handler(context, toDiff, aspect),
-            ... _.map(_.difference(diffs, toDiff), () => {
-                return {abstain: true};
-             }),
+            ... _.map(_.difference(diffs, toDiff), () => ({abstain: true})),
         ];
     };
 }

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -187,7 +187,6 @@ export const computeFingerprints: FingerprintComputer = async (fingerprinters, p
         }
     }
 
-
     const consolidatedFingerprints = [];
     for (const cfp of fingerprinters.filter(f => !!f.consolidate)) {
         consolidatedFingerprints.push(await cfp.consolidate(extracted));

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -20,12 +20,8 @@ import {
     Project,
     QueryNoCacheOptions,
 } from "@atomist/automation-client";
-import {
-    renderData,
-} from "@atomist/clj-editors";
-import {
-    PushImpactListenerInvocation,
-} from "@atomist/sdm";
+import { renderData } from "@atomist/clj-editors";
+import { PushImpactListenerInvocation } from "@atomist/sdm";
 import * as _ from "lodash";
 import { sendFingerprintToAtomist } from "../adhoc/fingerprints";
 import { getFPTargets } from "../adhoc/preferences";
@@ -239,7 +235,7 @@ export function fingerprintRunner(
 
         const allFps = await computer(fingerprinters, p);
 
-        logger.debug(`Prosessing fingerprints: ${renderData(allFps)}`);
+        logger.debug(`Processing fingerprints: ${renderData(allFps)}`);
 
         await sendFingerprintToAtomist(i, allFps, previous);
 

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -175,18 +175,24 @@ export type FingerprintComputer = (fingerprinters: Aspect[], p: Project) => Prom
 
 export const computeFingerprints: FingerprintComputer = async (fingerprinters, p) => {
 
-    const extacted: FP[] = [];
+    const extracted: FP[] = [];
     for (const x of fingerprinters) {
         const fpOrFps = await x.extract(p);
         if (fpOrFps) {
             if (Array.isArray(fpOrFps)) {
-                _.concat(extacted, fpOrFps);
+                _.concat(extracted, fpOrFps);
             } else {
-                extacted.push( fpOrFps );
+                extracted.push( fpOrFps );
             }
         }
     }
-    return extacted;
+
+
+    const consolidatedFingerprints = [];
+    for (const cfp of fingerprinters.filter(f => !!f.consolidate)) {
+        consolidatedFingerprints.push(await cfp.consolidate(extracted));
+    }
+    return [...extracted, ...consolidatedFingerprints];
 };
 
 /**

--- a/lib/support/messages.ts
+++ b/lib/support/messages.ts
@@ -15,9 +15,7 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import {
-    consistentHash,
-} from "@atomist/clj-editors";
+import { consistentHash } from "@atomist/clj-editors";
 import {
     codeBlock,
     codeLine,

--- a/lib/support/util.ts
+++ b/lib/support/util.ts
@@ -49,10 +49,3 @@ export function orDefault<T>(cb: () => T, x: T): T {
         return x;
     }
 }
-
-export async function promiseAllSeq<T>(things: Array<Promise<T>>): Promise<T[]> {
-    return _.reduce(things, async (acc, thing) => {
-     (await acc).push(await thing);
-     return acc;
-    }, Promise.resolve([] as T[]));
-}

--- a/lib/support/util.ts
+++ b/lib/support/util.ts
@@ -49,3 +49,10 @@ export function orDefault<T>(cb: () => T, x: T): T {
         return x;
     }
 }
+
+export async function promiseAllSeq<T>(things: Array<Promise<T>>): Promise<T[]> {
+    return _.reduce(things, async (acc, thing) => {
+     (await acc).push(await thing);
+     return acc;
+    }, Promise.resolve([] as T[]));
+}

--- a/lib/support/util.ts
+++ b/lib/support/util.ts
@@ -19,7 +19,8 @@ import {
     SlackFileMessage,
 } from "@atomist/automation-client";
 import {
-    DiffData, renderDiff,
+    DiffData,
+    renderDiff,
 } from "@atomist/clj-editors";
 import { SlackMessage } from "@atomist/slack-messages";
 import * as _ from "lodash";

--- a/lib/support/util.ts
+++ b/lib/support/util.ts
@@ -19,11 +19,10 @@ import {
     SlackFileMessage,
 } from "@atomist/automation-client";
 import {
-    renderDiff,
+    DiffData, renderDiff,
 } from "@atomist/clj-editors";
 import { SlackMessage } from "@atomist/slack-messages";
 import * as _ from "lodash";
-import { Diff } from "../machine/Aspect";
 
 export function comparator(path: string): (a: any, b: any) => number {
     return (a, b) => {
@@ -33,7 +32,7 @@ export function comparator(path: string): (a: any, b: any) => number {
     };
 }
 
-export async function renderDiffSnippet(ctx: HandlerContext, diff: Diff): Promise<void> {
+export async function renderDiffSnippet(ctx: HandlerContext, diff: DiffData): Promise<void> {
     const message: SlackFileMessage = {
         content: renderDiff(diff),
         fileType: "text",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,7 +2622,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
@@ -3201,7 +3201,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -3708,7 +3708,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3832,7 +3832,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -8014,7 +8014,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -8055,7 +8055,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -8064,7 +8064,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -8786,7 +8786,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -9508,7 +9508,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10515,7 +10515,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -11252,7 +11252,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-fingerprints",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -214,9 +214,9 @@
       }
     },
     "@atomist/clj-editors": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@atomist/clj-editors/-/clj-editors-0.8.1.tgz",
-      "integrity": "sha512-2iizBH5ocJo+iNBvuAuyM501j406cEbOpc3xa/5zg5HwnMCMx10+5/1nN7QPKiiWjOsCBSBsB1fiVvGuMfKdLg==",
+      "version": "0.8.2-master.20190816115246",
+      "resolved": "https://registry.npmjs.org/@atomist/clj-editors/-/clj-editors-0.8.2-master.20190816115246.tgz",
+      "integrity": "sha512-9x223UcwxYEhuBGVq7H3H5JzdpG81tbog2y4o6oDNpmBzncZ3nKEZwkXUromHaC9TRya0zWVW7HklBdTE5fCsg==",
       "requires": {
         "@cljs-oss/module-deps": "^1.1.1",
         "semver": "^5.5.0",
@@ -225,9 +225,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -1581,15 +1581,6 @@
       "integrity": "sha512-okXbUmdZFMO3AYBEJCcpJFPFDkKmIiZZBqWD5TmPtAv+GHfjD2qLZEI0PvZ8IWMU4ozoK2HV2lDxWjw4LbVlnw==",
       "dev": true
     },
-    "@types/handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "*"
-      }
-    },
     "@types/helmet": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/@types/helmet/-/helmet-0.0.43.tgz",
@@ -1598,12 +1589,6 @@
       "requires": {
         "@types/express": "*"
       }
-    },
-    "@types/highlight.js": {
-      "version": "9.12.3",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-      "dev": true
     },
     "@types/inquirer": {
       "version": "0.0.43",
@@ -1643,12 +1628,6 @@
       "version": "4.14.136",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
       "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
-      "dev": true
-    },
-    "@types/marked": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
       "dev": true
     },
     "@types/mime": {
@@ -2643,7 +2622,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
@@ -2839,6 +2818,15 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3213,7 +3201,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -3720,7 +3708,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3844,7 +3832,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -5067,25 +5055,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5095,13 +5087,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5111,37 +5105,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5150,25 +5150,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5177,13 +5181,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5199,7 +5205,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5213,13 +5220,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5228,7 +5237,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5237,7 +5247,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5247,19 +5258,22 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5268,13 +5282,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5283,13 +5299,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5299,7 +5317,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5308,7 +5327,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5317,13 +5337,15 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5334,7 +5356,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5352,7 +5375,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5362,13 +5386,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5378,7 +5404,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5390,19 +5417,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5411,19 +5441,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5433,19 +5466,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5457,7 +5493,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -5465,7 +5502,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5480,7 +5518,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5489,43 +5528,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5536,7 +5582,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5545,7 +5592,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5554,13 +5602,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5575,13 +5625,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5590,13 +5642,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
         }
@@ -6520,9 +6574,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.15.8",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
-      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==",
+      "version": "9.15.9",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
+      "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
       "dev": true
     },
     "hoek": {
@@ -7278,6 +7332,12 @@
         "topo": "3.x.x"
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -7560,9 +7620,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -7769,6 +7829,12 @@
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
       "dev": true
     },
+    "lunr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
+      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+      "dev": true
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -7805,9 +7871,9 @@
       }
     },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
     "media-typer": {
@@ -7948,7 +8014,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -7989,7 +8055,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7998,7 +8064,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -8720,7 +8786,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -9442,7 +9508,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10449,7 +10515,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -10822,63 +10888,35 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedoc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^5.0.3",
-        "@types/handlebars": "^4.0.38",
-        "@types/highlight.js": "^9.12.3",
-        "@types/lodash": "^4.14.110",
-        "@types/marked": "^0.4.0",
         "@types/minimatch": "3.0.3",
-        "@types/shelljs": "^0.8.0",
-        "fs-extra": "^7.0.0",
-        "handlebars": "^4.0.6",
-        "highlight.js": "^9.13.1",
-        "lodash": "^4.17.10",
-        "marked": "^0.4.0",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.1.2",
+        "highlight.js": "^9.15.8",
+        "lodash": "^4.17.15",
+        "marked": "^0.7.0",
         "minimatch": "^3.0.0",
-        "progress": "^2.0.0",
-        "shelljs": "^0.8.2",
-        "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.2.x"
-      },
-      "dependencies": {
-        "@types/fs-extra": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-          "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "typescript": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
-          "dev": true
-        }
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "^0.6.0",
+        "typescript": "3.5.x"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
+      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.6",
+        "underscore": "^1.9.1"
+      }
     },
     "typescript": {
       "version": "3.5.3",
@@ -11214,7 +11252,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-fingerprints",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "description": "an Atomist SDM Extension Pack for fingerprinting code",
   "author": {
     "name": "Atomist",
@@ -24,10 +24,10 @@
     "url": "https://github.com/atomist/sdm-pack-fingerprints/issues"
   },
   "dependencies": {
-    "@atomist/clj-editors": "0.8.1",
+    "@atomist/clj-editors": "0.8.2-master.20190816115246",
     "@atomist/slack-messages": "^1.1.1",
     "@cljs-oss/module-deps": "^1.1.1",
-    "lodash": "^4.17.14"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "@atomist/automation-client": ">=1.6.0",
@@ -53,7 +53,7 @@
     "tmp-promise": "^2.0.2",
     "ts-node": "8.3.0",
     "tslint": "^5.18.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.15.0",
     "typescript": "^3.5.3"
   },
   "directories": {

--- a/test/fingerprints/atomicAspect.test.ts
+++ b/test/fingerprints/atomicAspect.test.ts
@@ -108,7 +108,7 @@ describe("atomicAspect", () => {
             name: "foo",
             apply: async p1 => {
                 await p1.addFile("f1", "content");
-                return true;
+                return p1;
             },
         };
         const f2: Aspect = {
@@ -117,7 +117,7 @@ describe("atomicAspect", () => {
             name: "bar",
             apply: async p2 => {
                 await p2.addFile("f2", "content");
-                return true;
+                return p2;
             },
         };
 
@@ -141,7 +141,7 @@ describe("atomicAspect", () => {
 
         // apply consolidated fingerprint and ensure both apply functions run
         const p = InMemoryProject.of();
-        await aspect.apply(p, consolidated);
+        await aspect.apply(p, { parameters: { fp: consolidated } } as any);
         assert(await p.hasFile("f1"));
         assert(await p.hasFile("f2"));
     });

--- a/test/fingerprints/defaultTargetDiffHandler.test.ts
+++ b/test/fingerprints/defaultTargetDiffHandler.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SdmContext } from "@atomist/sdm";
+import * as assert from "assert";
+import { Aspect } from "../../lib/machine/Aspect";
+import { DefaultTargetDiffHandler } from "../../lib/machine/fingerprintSupport";
+
+describe("DefaultTargetDiffHandler", () => {
+    it("we always abstain if there is no previous FP", () => {
+        // tslint:disable-next-line:no-object-literal-type-assertion
+        const ctx = {} as SdmContext;
+        const diffs = [{
+            targets: {},
+            to: {
+                type: "type",
+                name: "name",
+                sha: "sha",
+                data: "somedata",
+            },
+            data: { from: ["blah"], to: ["blah"] },
+            owner: "blah",
+            repo: "blah",
+            sha: "sha",
+            providerId: "pid",
+            channel: "blah",
+            branch: "master",
+        }] as any;
+        // tslint:disable-next-line:no-object-literal-type-assertion
+        const aspect = {} as Aspect;
+        return DefaultTargetDiffHandler(ctx, diffs, aspect).then(votes =>
+            votes.forEach(vote => assert.deepStrictEqual(vote, { abstain: true })));
+    });
+});


### PR DESCRIPTION
- Diff.from is now optional so that initial fingerprints can be handled
- Handlers/workflows now take arrays of Diffs of same type so that aggregates can be calculated/handled within Aspects
- FP.type is now mandatory - we always need this, and this removes the ambiguity