### PR TITLE
Simplify typing of Aspect and remove unused members

### DIFF
--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {logger} from "@atomist/automation-client";
+import { logger } from "@atomist/automation-client";
 import {
     ApplyFingerprint,
     ExtractFingerprint, FP,
     sha256,
 } from "../..";
-import {Aspect} from "../machine/Aspect";
+import { Aspect } from "../machine/Aspect";
 
 export interface FileFingerprintData {
     filename: string;

--- a/lib/fingerprints/jsonFiles.ts
+++ b/lib/fingerprints/jsonFiles.ts
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-import { logger } from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {
     ApplyFingerprint,
-    ExtractFingerprint,
-    FP,
+    ExtractFingerprint, FP,
     sha256,
 } from "../..";
-import { Aspect } from "../machine/Aspect";
+import {Aspect} from "../machine/Aspect";
 
-export interface FileFingerprint extends FP {
-    data: {
-        filename: string;
-        content: string;
-    };
+export interface FileFingerprintData {
+    filename: string;
+    content: string;
 }
 
 /**
@@ -35,7 +32,7 @@ export interface FileFingerprint extends FP {
  * @param {string} filenames
  * @return {ExtractFingerprint}
  */
-export function createFileFingerprint(...filenames: string[]): ExtractFingerprint {
+export function createFileFingerprint(...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return createFilesFingerprint(
         "json-file",
         content => JSON.parse(content),
@@ -51,9 +48,9 @@ export function createFileFingerprint(...filenames: string[]): ExtractFingerprin
  */
 export function createFilesFingerprint(type: string,
                                        canonicalize: (content: string) => any,
-                                       ...filenames: string[]): ExtractFingerprint<FileFingerprint> {
+                                       ...filenames: string[]): ExtractFingerprint<FileFingerprintData> {
     return async p => {
-        const fps: FileFingerprint[] = [];
+        const fps: Array<FP<FileFingerprintData>> = [];
         await Promise.all(
             filenames.map(async filename => {
                     const file = await p.getFile(filename);
@@ -82,7 +79,7 @@ export function createFilesFingerprint(type: string,
     };
 }
 
-export const applyFileFingerprint: ApplyFingerprint = async (p, fp) => {
+export const applyFileFingerprint: ApplyFingerprint<FileFingerprintData> = async (p, fp) => {
     const file = await p.getFile(fp.data.filename);
 
     if (file) {
@@ -96,7 +93,7 @@ export const applyFileFingerprint: ApplyFingerprint = async (p, fp) => {
     }
 };
 
-export const JsonFile: Aspect = {
+export const JsonFile: Aspect<FileFingerprintData> = {
     displayName: "JSON files",
     name: "json-file",
     extract: createFileFingerprint(
@@ -113,9 +110,9 @@ export const JsonFile: Aspect = {
 export function filesAspect(opts: {
                                 type: string,
                                 canonicalize: (content: string) => any,
-                            } & Pick<Aspect<FileFingerprint>, "name" | "displayName" |
+                            } & Pick<Aspect<FileFingerprintData>, "name" | "displayName" |
                                 "toDisplayableFingerprintName" | "toDisplayableFingerprint">,
-                            ...files: string[]): Aspect<FileFingerprint> {
+                            ...files: string[]): Aspect<FileFingerprintData> {
     return {
         ...opts,
         extract: createFilesFingerprint(

--- a/lib/fingerprints/npmDeps.ts
+++ b/lib/fingerprints/npmDeps.ts
@@ -92,7 +92,7 @@ export function deconstructNpmDepsFingerprintName(fingerprintName: string): stri
     }
 }
 
-export const createNpmDepsFingerprints: ExtractFingerprint<FP<NpmDepData>> = async p => {
+export const createNpmDepsFingerprints: ExtractFingerprint<NpmDepData> = async p => {
     const file = await p.getFile("package.json");
 
     if (file) {
@@ -137,7 +137,7 @@ export const createNpmCoordinatesFingerprint: ExtractFingerprint = async p => {
 
 };
 
-export const applyNpmDepsFingerprint: ApplyFingerprint<FP<NpmDepData>> = async (p, fp) => {
+export const applyNpmDepsFingerprint: ApplyFingerprint<NpmDepData> = async (p, fp) => {
     const pckage = fp.data[0];
     const version = fp.data[1];
     const file = await p.getFile("package.json");
@@ -183,7 +183,7 @@ const NpmDepsName = "npm-project-deps";
 /**
  * Aspect emitting 0 or more npm dependencies fingerprints.
  */
-export const NpmDeps: Aspect<FP<NpmDepData>> = {
+export const NpmDeps: Aspect<NpmDepData> = {
     displayName: "NPM dependencies",
     name: NpmDepsName,
     extract: createNpmDepsFingerprints,

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -44,12 +44,12 @@ export interface FP<DATA = any> {
     path?: string;
 }
 
-export interface Vote {
+export interface Vote<DATA = any> {
     abstain: boolean;
     decision?: string;
     name?: string;
-    fingerprint?: FP;
-    fpTarget?: FP;
+    fingerprint?: FP<DATA>;
+    fpTarget?: FP<DATA>;
     diff?: Diff;
     text?: string;
     summary?: { title: string, description: string };
@@ -58,9 +58,9 @@ export interface Vote {
 /**
  * Difference between two fingerprints
  */
-export interface Diff {
-    from: FP;
-    to: FP;
+export interface Diff<DATA = any> {
+    from: FP<DATA>;
+    to: FP<DATA>;
     data: {
         from: any[];
         to: any[];
@@ -77,21 +77,21 @@ export interface Diff {
  * Extract fingerprint(s) from the given project.
  * Return undefined or the empty array if no fingerprints found.
  */
-export type ExtractFingerprint<FPI extends FP = FP> = (p: Project) => Promise<FPI | FPI[]>;
+export type ExtractFingerprint<DATA = any> = (p: Project) => Promise<FP<DATA> | Array<FP<DATA>>>;
 
 export type FingerprintSelector = (fingerprint: FP) => boolean;
 
 /**
  * Apply the given fingerprint to the project
  */
-export type ApplyFingerprint<FPI extends FP = FP> = (p: Project, fp: FPI) => Promise<boolean>;
+export type ApplyFingerprint<DATA = any> = (p: Project, fp: FP<DATA>) => Promise<boolean>;
 
 export interface DiffSummary {
     title: string;
     description: string;
 }
 
-export type DiffSummaryFingerprint = (diff: Diff, target: FP) => DiffSummary;
+export type DiffSummaryFingerprint<DATA = any> = (diff: Diff<DATA>, target: FP<DATA>) => DiffSummary;
 
 /**
  * Aspects add the ability to manage a particular type of fingerprint:
@@ -106,7 +106,7 @@ export type DiffSummaryFingerprint = (diff: Diff, target: FP) => DiffSummary;
  * extracted fingerprints, or extracted throughout the delivery lifecycle
  * from Atomist events.
  */
-export interface Aspect<FPI extends FP = FP> {
+export interface Aspect<DATA = any> {
 
     /**
      * Displayable name of this aspect. Used only for reporting.
@@ -135,26 +135,26 @@ export interface Aspect<FPI extends FP = FP> {
      * Function to extract fingerprint(s) from this project.
      * Return an empty array if none.
      */
-    extract: ExtractFingerprint<FPI>;
+    extract: ExtractFingerprint<DATA>;
 
     /**
      * Function to create any new fingerprint based on fingerprinters
      * found by extract method.
      */
-    consolidate?: (fps: FP[]) => Promise<FPI>;
+    consolidate?: (fps: FP[]) => Promise<FP<DATA>>;
 
     /**
      * Function to apply the given fingerprint instance to a project
      */
-    apply?: ApplyFingerprint<FPI>;
+    apply?: ApplyFingerprint<DATA>;
 
-    summary?: DiffSummaryFingerprint;
+    summary?: DiffSummaryFingerprint<DATA>;
 
     /**
      * Convert a fingerprint value to a human readable string
      * fpi.data is a reasonable default
      */
-    toDisplayableFingerprint?(fpi: FPI): string;
+    toDisplayableFingerprint?(fp: FP<DATA>): string;
 
     /**
      * Convert a fingerprint name such as "npm-project-dep::atomist::automation-client"

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -17,7 +17,6 @@
 import {
     HandlerContext,
     Project,
-    ReviewComment,
 } from "@atomist/automation-client";
 import { SdmContext } from "@atomist/sdm";
 import { GitCoordinate } from "../support/messages";
@@ -95,15 +94,6 @@ export interface DiffSummary {
 export type DiffSummaryFingerprint = (diff: Diff, target: FP) => DiffSummary;
 
 /**
- * Implemented by types that know how to compare two fingerprints,
- * for example by quality or up-to-dateness
- */
-export interface FingerprintComparator<FPI extends FP = FP> {
-    readonly name: string;
-    comparator: (a: FPI, b: FPI) => number;
-}
-
-/**
  * Aspects add the ability to manage a particular type of fingerprint:
  * for example, helping with convergence across an organization and supporting
  * visualization. Aspects are typically extracted from a Project (see Aspect)
@@ -161,12 +151,6 @@ export interface Aspect<FPI extends FP = FP> {
     summary?: DiffSummaryFingerprint;
 
     /**
-     * Functions that can be used to compare fingerprint instances managed by this
-     * aspect.
-     */
-    comparators?: Array<FingerprintComparator<FPI>>;
-
-    /**
      * Convert a fingerprint value to a human readable string
      * fpi.data is a reasonable default
      */
@@ -179,12 +163,6 @@ export interface Aspect<FPI extends FP = FP> {
      * @return {string}
      */
     toDisplayableFingerprintName?(fingerprintName: string): string;
-
-    /**
-     * Validate the aspect. Return undefined or the empty array if there are no problems.
-     * @return {Promise<ReviewComment[]>}
-     */
-    validate?(fpi: FPI): Promise<ReviewComment[]>;
 
     /**
      * Based on the given fingerprint type and name, suggest ideals

--- a/lib/machine/AtomicAspect.ts
+++ b/lib/machine/AtomicAspect.ts
@@ -21,7 +21,7 @@ import {
     FingerprintSelector,
     FP,
 } from "./Aspect";
-import {aspectOf} from "./Aspects";
+import { aspectOf } from "./Aspects";
 
 /**
  * Create a composite aspect from the given other aspects or extractors.

--- a/lib/machine/AtomicAspect.ts
+++ b/lib/machine/AtomicAspect.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { sha256 } from "@atomist/clj-editors";
+import {sha256} from "@atomist/clj-editors";
 import {
     ApplyFingerprint,
     Aspect,
     FingerprintSelector,
     FP,
 } from "./Aspect";
-import { aspectOf } from "./Aspects";
+import {aspectOf} from "./Aspects";
 
 /**
  * Create a composite aspect from the given other aspects or extractors.
@@ -34,7 +34,7 @@ import { aspectOf } from "./Aspects";
  */
 export function atomicAspect(
     aspectData: Pick<Aspect, "displayName" | "summary" |
-        "comparators" | "toDisplayableFingerprint" | "toDisplayableFingerprintName" | "name">,
+        "toDisplayableFingerprint" | "toDisplayableFingerprintName" | "name">,
     narrower: FingerprintSelector,
     aspect0: Aspect,
     ...aspects: Aspect[]): Aspect {

--- a/test/fingerprints/virtual-project/makeVirtualProjectAware.test.ts
+++ b/test/fingerprints/virtual-project/makeVirtualProjectAware.test.ts
@@ -24,7 +24,6 @@ import {
     ApplyFingerprint,
     Aspect,
     ExtractFingerprint,
-    FP,
 } from "../../../lib/machine/Aspect";
 
 import * as assert from "assert";
@@ -46,7 +45,7 @@ const extractThing: ExtractFingerprint = async p => {
     };
 };
 
-const applyThing: ApplyFingerprint<FP<{ path: string, content: string }>> = async (p, fpi) => {
+const applyThing: ApplyFingerprint<{ path: string, content: string }> = async (p, fpi) => {
     await p.addFile(fpi.data.path, fpi.data.content);
     return true;
 };


### PR DESCRIPTION
Previously a strongly typed Aspect was of the form `Aspect<FP<DataType>>`.

This changes to be `Aspect<DataType`>.

This is more readable and reflects the learning that `FP` should not be extended except by changing the `data` property type.

Also removes unused members of `Aspect`: `comparators` and `validate`.  These may be worthwhile, but as they are not yet being used, it's good to simplify the interface for now.

_This change is not backward compatible_. Any typed aspects will need to change. However, the change is straightforward. See npm dependencies aspect as any example.