### PR TITLE
Update runner and extension pack to understand virtual projects

### DIFF
--- a/lib/checktarget/callbacks.ts
+++ b/lib/checktarget/callbacks.ts
@@ -75,11 +75,7 @@ function fingerprintOutOfSyncCallback(
 }
 
 /**
- * create callback to be used when fingerprint and target is in sync
- *
- * @param ctx
- * @param diff
- * @param goal
+ * Create callback to be used when fingerprint and target is in sync
  */
 function fingerprintInSyncCallback(ctx: HandlerContext, diff: Diff): (fingerprint: FP) => Promise<Vote> {
     return async fingerprint => {
@@ -178,12 +174,6 @@ export function votes(config: FingerprintOptions & FingerprintImpactHandlerConfi
 
 /**
  * check whether the fingerprint in this diff is the same as the target value
- *
- * @param ctx
- * @param diff
- * @param config
- * @param registrations
- * @param targetsQuery
  */
 export async function checkFingerprintTarget(
     ctx: HandlerContext,

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Project} from "@atomist/automation-client";
+import { Project } from "@atomist/automation-client";
 // tslint:disable:deprecation
-import {chainTransforms} from "@atomist/sdm";
+import { chainTransforms } from "@atomist/sdm";
 import * as _ from "lodash";
 import {
     ApplyFingerprint,
@@ -24,7 +24,7 @@ import {
     ExtractFingerprint,
     FP,
 } from "../../machine/Aspect";
-import {localProjectUnder} from "./support/localProjectUnder";
+import { localProjectUnder } from "./support/localProjectUnder";
 import {
     VirtualProjectFinder,
     VirtualProjectStatus,

--- a/lib/machine/Aspect.ts
+++ b/lib/machine/Aspect.ts
@@ -139,10 +139,11 @@ export interface Aspect<DATA = any> {
     extract: ExtractFingerprint<DATA>;
 
     /**
-     * Function to create any new fingerprint based on fingerprinters
-     * found by extract method.
+     * Function to create any new fingerprint based on fingerprints
+     * found by extract method. Implementations must observe the path
+     * (if set) in the original fingerprints.
      */
-    consolidate?: (fps: FP[]) => Promise<FP<DATA>>;
+    consolidate?: (fps: FP[]) => Promise<FP<DATA> | Array<FP<DATA>>>;
 
     /**
      * Function to apply the given fingerprint instance to a project

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Project} from "@atomist/automation-client";
+import { Project } from "@atomist/automation-client";
 import {
     AutoMerge,
     AutoMergeMethod,
@@ -31,16 +31,16 @@ import {
     SoftwareDeliveryMachine,
     TransformPresentation,
 } from "@atomist/sdm";
-import {toArray} from "@atomist/sdm-core/lib/util/misc/array";
+import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
-import {checkFingerprintTarget} from "../checktarget/callbacks";
+import { checkFingerprintTarget } from "../checktarget/callbacks";
 import {
     ignoreCommand,
     messageMaker,
     MessageMaker,
 } from "../checktarget/messageMaker";
-import {makeVirtualProjectAware} from "../fingerprints/virtual-project/makeVirtualProjectAware";
-import {VirtualProjectFinder} from "../fingerprints/virtual-project/VirtualProjectFinder";
+import { makeVirtualProjectAware } from "../fingerprints/virtual-project/makeVirtualProjectAware";
+import { VirtualProjectFinder } from "../fingerprints/virtual-project/VirtualProjectFinder";
 import {
     applyTarget,
     applyTargetBySha,
@@ -48,8 +48,8 @@ import {
     applyTargets,
     broadcastFingerprintMandate,
 } from "../handlers/commands/applyFingerprint";
-import {broadcastFingerprintNudge} from "../handlers/commands/broadcast";
-import {FingerprintMenu} from "../handlers/commands/fingerprints";
+import { broadcastFingerprintNudge } from "../handlers/commands/broadcast";
+import { FingerprintMenu } from "../handlers/commands/fingerprints";
 import {
     listFingerprint,
     listFingerprints,

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -22,7 +22,7 @@ import {
 } from "@atomist/automation-client";
 import { renderData } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
-import {toArray} from "@atomist/sdm-core/lib/util/misc/array";
+import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
 import { sendFingerprintToAtomist } from "../adhoc/fingerprints";
 import { getFPTargets } from "../adhoc/preferences";

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -22,6 +22,7 @@ import {
 } from "@atomist/automation-client";
 import { renderData } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
+import {toArray} from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
 import { sendFingerprintToAtomist } from "../adhoc/fingerprints";
 import { getFPTargets } from "../adhoc/preferences";
@@ -57,7 +58,7 @@ interface MissingInfo {
 /**
  * Give each Aspect the opportunity to evaluate the current FP, the previous FP, and any target FP
  *
- * @param fp current Fingerprint
+ * @param fps current fingerprints
  * @param previous Fingeprint from Push.before (could be nil)
  * @param info missing info
  * @param handlers deprecated handlers
@@ -170,25 +171,26 @@ async function missingInfo(i: PushImpactListenerInvocation): Promise<MissingInfo
 
 export type FingerprintRunner = (i: PushImpactListenerInvocation) => Promise<FP[]>;
 
-export type FingerprintComputer = (fingerprinters: Aspect[], p: Project) => Promise<FP[]>;
+export type FingerprintComputer = (options: FingerprintOptions, p: Project) => Promise<FP[]>;
 
-export const computeFingerprints: FingerprintComputer = async (fingerprinters, p) => {
-
+export const computeFingerprints: FingerprintComputer = async (options, p) => {
     const extracted: FP[] = [];
-    for (const x of fingerprinters) {
-        const fpOrFps = await x.extract(p);
+    const aspects = toArray(options.aspects);
+    if (options.virtualProjectFinder) {
+        // Seed the VirtualProjectFinder, which may need to cache
+        await options.virtualProjectFinder.findVirtualProjectInfo(p);
+    }
+    for (const x of aspects) {
+        const fpOrFps = toArray(await x.extract(p));
         if (fpOrFps) {
-            if (Array.isArray(fpOrFps)) {
-                _.concat(extracted, fpOrFps);
-            } else {
-                extracted.push( fpOrFps );
-            }
+            extracted.push(...fpOrFps);
         }
     }
 
     const consolidatedFingerprints = [];
-    for (const cfp of fingerprinters.filter(f => !!f.consolidate)) {
-        consolidatedFingerprints.push(await cfp.consolidate(extracted));
+    for (const cfp of aspects.filter(f => !!f.consolidate)) {
+        const consolidated: FP[] = toArray(await cfp.consolidate(extracted));
+        consolidatedFingerprints.push(...consolidated);
     }
     return [...extracted, ...consolidatedFingerprints];
 };
@@ -199,17 +201,15 @@ export const computeFingerprints: FingerprintComputer = async (fingerprinters, p
 export function fingerprintRunner(
     fingerprinters: Aspect[],
     handlers: FingerprintHandler[],
-    computer: (fingerprinters: Aspect[], p: Project) => Promise<FP[]>,
+    computer: FingerprintComputer,
     options: FingerprintOptions & FingerprintImpactHandlerConfig = {
         aspects: [],
         transformPresentation: DefaultTransformPresentation,
         messageMaker,
     }): FingerprintRunner {
-
     const targetDiffBallot = votes(options);
 
     const tallyVotes = async (vts: Vote[], fingerprintHandlers: FingerprintHandler[], i: PushImpactListenerInvocation, info: MissingInfo) => {
-
         const coordinate: GitCoordinate = {
             owner: i.push.repo.owner,
             repo: i.push.repo.name,
@@ -237,7 +237,7 @@ export function fingerprintRunner(
         }
         logger.info(`Found ${Object.keys(previous).length} fingerprints`);
 
-        const allFps = await computer(fingerprinters, p);
+        const allFps = await computer(options, p);
 
         logger.debug(`Processing fingerprints: ${renderData(allFps)}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,7 +1432,7 @@
     },
     "@types/app-root-path": {
       "version": "1.2.4",
-      "resolved": "http://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
@@ -1771,7 +1771,7 @@
     },
     "@types/rx": {
       "version": "4.1.1",
-      "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
       "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
       "dev": true,
       "requires": {
@@ -3201,7 +3201,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -3708,7 +3708,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3832,7 +3832,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -4197,7 +4197,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4867,7 +4867,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -8014,7 +8014,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -8786,7 +8786,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -10409,7 +10409,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -11252,7 +11252,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,7 +1432,7 @@
     },
     "@types/app-root-path": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
+      "resolved": "http://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
@@ -1771,7 +1771,7 @@
     },
     "@types/rx": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
       "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
       "dev": true,
       "requires": {
@@ -3201,7 +3201,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -3708,7 +3708,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3832,7 +3832,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -4197,7 +4197,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4867,7 +4867,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -8014,7 +8014,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -8786,7 +8786,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -10409,7 +10409,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -11252,7 +11252,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/test/fingerprints/atomicAspect.test.ts
+++ b/test/fingerprints/atomicAspect.test.ts
@@ -23,9 +23,12 @@ import {
 } from "../../lib/fingerprints/npmDeps";
 import {
     Aspect,
-    ExtractFingerprint,
+    ExtractFingerprint, FP,
 } from "../../lib/machine/Aspect";
 import { atomicAspect } from "../../lib/machine/AtomicAspect";
+
+// Prevent necessary type casts being removed
+//tslint:disable
 
 describe("atomicAspect", () => {
 
@@ -132,7 +135,7 @@ describe("atomicAspect", () => {
             f2);
 
         // create consolidated fingerprint for Atomist Aspect
-        const consolidated = await aspect.consolidate([fp1, fp2]);
+        const consolidated = await aspect.consolidate([fp1, fp2]) as FP;
 
         // check consolidated fingerprint
         assert(!!consolidated);

--- a/test/fingerprints/atomicAspect.test.ts
+++ b/test/fingerprints/atomicAspect.test.ts
@@ -23,7 +23,8 @@ import {
 } from "../../lib/fingerprints/npmDeps";
 import {
     Aspect,
-    ExtractFingerprint, FP,
+    ExtractFingerprint,
+    FP,
 } from "../../lib/machine/Aspect";
 import { atomicAspect } from "../../lib/machine/AtomicAspect";
 

--- a/test/fingerprints/virtual-project/makeVirtualProjectAware.test.ts
+++ b/test/fingerprints/virtual-project/makeVirtualProjectAware.test.ts
@@ -27,7 +27,8 @@ import {
 import {
     ApplyFingerprint,
     Aspect,
-    ExtractFingerprint, FP,
+    ExtractFingerprint,
+    FP,
 } from "../../../lib/machine/Aspect";
 import { tempProject } from "./tempProject";
 

--- a/test/machine/runner.test.ts
+++ b/test/machine/runner.test.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import {InMemoryProject} from "@atomist/automation-client";
+import { InMemoryProject } from "@atomist/automation-client";
 import {sha256} from "@atomist/clj-editors";
 import * as assert from "assert";
-import {makeVirtualProjectAware} from "../../lib/fingerprints/virtual-project/makeVirtualProjectAware";
-import {RootIsOnlyProject, VirtualProjectFinder} from "../../lib/fingerprints/virtual-project/VirtualProjectFinder";
-import {Aspect} from "../../lib/machine/Aspect";
-import {computeFingerprints} from "../../lib/machine/runner";
+import { makeVirtualProjectAware } from "../../lib/fingerprints/virtual-project/makeVirtualProjectAware";
+import {
+    RootIsOnlyProject,
+    VirtualProjectFinder,
+} from "../../lib/fingerprints/virtual-project/VirtualProjectFinder";
+import { Aspect } from "../../lib/machine/Aspect";
+import { computeFingerprints } from "../../lib/machine/runner";
 
 function alwaysFindAspect(name: string): Aspect {
     return {


### PR DESCRIPTION
- Extension pack now takes optional `VirtualProjectFinder` and makes aspects virtual project aware in that case
- `Aspect.consolidate` can now return `FP` or `FP[]`
- Fix bug in runner function with array return fingerprints

Backward compatible.