### PR TITLE
Introduce FingerprintPublisher type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,6 +80,8 @@ export {
 } from "./lib/handlers/commands/applyFingerprint";
 export * from "./lib/fingerprints/jsonFiles";
 
+export { PublishFingerprints } from "./lib/adhoc/fingerprints";
+
 export * from "./lib/machine/AtomicAspect";
 
 export * from "./lib/machine/Ideal";

--- a/lib/adhoc/fingerprints.ts
+++ b/lib/adhoc/fingerprints.ts
@@ -67,8 +67,12 @@ export function queryFingerprintsByBranchRef(graphClient: GraphClient):
     };
 }
 
-export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, fps: FP[], previous: Record<string, FP>): Promise<boolean> {
+/**
+ * Do something with fingerprints. Normally, send them to Atomist
+ */
+export type PublishFingerprints = (i: PushImpactListenerInvocation, fps: FP[], previous: Record<string, FP>) => Promise<boolean>;
 
+export const sendFingerprintsToAtomist: PublishFingerprints = async (i, fps, previous) => {
     try {
         // TODO use i.push and new sdm core to skip over this query entirely
         const ids: RepoBranchIds.Query = await i.context.graphClient.query<RepoBranchIds.Query, RepoBranchIds.Variables>(
@@ -105,4 +109,4 @@ export async function sendFingerprintToAtomist(i: PushImpactListenerInvocation, 
     }
 
     return true;
-}
+};

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Project} from "@atomist/automation-client";
+import { Project } from "@atomist/automation-client";
 // tslint:disable:deprecation
 import {
     chainTransforms,
@@ -27,7 +27,7 @@ import {
     ExtractFingerprint,
     FP,
 } from "../../machine/Aspect";
-import {localProjectUnder} from "./support/localProjectUnder";
+import { localProjectUnder } from "./support/localProjectUnder";
 import {
     VirtualProjectFinder,
     VirtualProjectStatus,

--- a/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
+++ b/lib/fingerprints/virtual-project/makeVirtualProjectAware.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Project } from "@atomist/automation-client";
+import {Project} from "@atomist/automation-client";
 // tslint:disable:deprecation
 import {
     chainTransforms,
@@ -27,7 +27,7 @@ import {
     ExtractFingerprint,
     FP,
 } from "../../machine/Aspect";
-import { localProjectUnder } from "./support/localProjectUnder";
+import {localProjectUnder} from "./support/localProjectUnder";
 import {
     VirtualProjectFinder,
     VirtualProjectStatus,
@@ -61,7 +61,8 @@ export function makeVirtualProjectAware<A extends Aspect>(aspect: A, virtualProj
  * @return {ExtractFingerprint}
  */
 export function makeExtractorVirtualProjectAware(ef: ExtractFingerprint,
-                                                 virtualProjectFinder: VirtualProjectFinder): (p: Project, i: PushImpactListenerInvocation) => Promise<FP[]> {
+                                                 virtualProjectFinder: VirtualProjectFinder):
+    (p: Project, i: PushImpactListenerInvocation) => Promise<FP[]> {
     return async (p, i) => {
         const virtualProjects = await virtualProjectsIn(p, virtualProjectFinder);
         const allReturns: FP[][] = await Promise.all(virtualProjects

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -33,6 +33,7 @@ import {
 } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
+import {PublishFingerprints, sendFingerprintsToAtomist} from "../adhoc/fingerprints";
 import { checkFingerprintTarget } from "../checktarget/callbacks";
 import {
     ignoreCommand,
@@ -169,6 +170,12 @@ export interface FingerprintOptions {
      * If provided, all aspects will be automatically be wrapped to use the VirtualProjectFinder.
      */
     virtualProjectFinder?: VirtualProjectFinder;
+
+    /**
+     * By default, fingerprints will be sent to Atomist. Set this in local mode etc
+     * to route them differently.
+     */
+    publishFingerprints?: PublishFingerprints;
 }
 
 export const DefaultTransformPresentation: TransformPresentation<ApplyTargetParameters> = createPullRequestTransformPresentation();
@@ -280,6 +287,7 @@ export function fingerprintSupport(options: FingerprintOptions): FingerprintExte
                 configuredAspects,
                 handlers,
                 fingerprintComputer,
+                options.publishFingerprints || sendFingerprintsToAtomist,
                 {
                     messageMaker,
                     transformPresentation: DefaultTransformPresentation,

--- a/lib/machine/fingerprintSupport.ts
+++ b/lib/machine/fingerprintSupport.ts
@@ -33,7 +33,10 @@ import {
 } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
-import {PublishFingerprints, sendFingerprintsToAtomist} from "../adhoc/fingerprints";
+import {
+    PublishFingerprints,
+    sendFingerprintsToAtomist,
+} from "../adhoc/fingerprints";
 import { checkFingerprintTarget } from "../checktarget/callbacks";
 import {
     ignoreCommand,

--- a/lib/machine/runner.ts
+++ b/lib/machine/runner.ts
@@ -24,7 +24,7 @@ import { renderData } from "@atomist/clj-editors";
 import { PushImpactListenerInvocation } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import * as _ from "lodash";
-import { sendFingerprintToAtomist } from "../adhoc/fingerprints";
+import { PublishFingerprints } from "../adhoc/fingerprints";
 import { getFPTargets } from "../adhoc/preferences";
 import { votes } from "../checktarget/callbacks";
 import { messageMaker } from "../checktarget/messageMaker";
@@ -204,6 +204,7 @@ export function fingerprintRunner(
     fingerprinters: Aspect[],
     handlers: FingerprintHandler[],
     computer: FingerprintComputer,
+    publishFingerprints: PublishFingerprints,
     options: FingerprintOptions & FingerprintImpactHandlerConfig = {
         aspects: [],
         transformPresentation: DefaultTransformPresentation,
@@ -243,7 +244,7 @@ export function fingerprintRunner(
 
         logger.debug(`Processing fingerprints: ${renderData(allFps)}`);
 
-        await sendFingerprintToAtomist(i, allFps, previous);
+        await publishFingerprints(i, allFps, previous);
 
         try {
             const info = await missingInfo(i);


### PR DESCRIPTION
Means we can route fingerprints differently in local mode, improving potential scope of `org-visualizer` and helping at development time.